### PR TITLE
Fix table root updates

### DIFF
--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -97,6 +97,13 @@ impl Catalog {
         })
     }
 
+    /// Mutable variant of `get_table` so callers can update the metadata.
+    pub fn get_table_mut(&mut self, name: &str) -> io::Result<&mut TableInfo> {
+        self.tables.get_mut(name).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::Other, format!("No such table: {}", name))
+        })
+    }
+
     /// Serialize a catalog row into a UTF-8 string:
     ///
     /// [u32 name_len][name_bytes][u32 root_page][u16 num_columns]

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,12 @@ fn main() -> io::Result<()> {
                                     warn!("Error inserting into {}: {}", table_name, e);
                                 } else {
                                     info!("Row inserted into '{}'", table_name);
+                                    let new_root = table_btree.root_page();
+                                    if new_root != root_page {
+                                        if let Ok(t) = catalog.get_table_mut(&table_name) {
+                                            t.root_page = new_root;
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -181,6 +187,10 @@ mod tests {
             let root_page = catalog.get_table("users").unwrap().root_page;
             let mut table_btree = BTree::open_root(&mut catalog.pager, root_page).unwrap();
             table_btree.insert(i as i32, &buf[..]).unwrap();
+            let new_root = table_btree.root_page();
+            if new_root != root_page {
+                catalog.get_table_mut("users").unwrap().root_page = new_root;
+            }
         }
 
         // 5) Now scan all rows in “users” and collect them.

--- a/src/storage/btree.rs
+++ b/src/storage/btree.rs
@@ -796,6 +796,12 @@ impl<'a> BTree<'a> {
         Ok(BTree { root_page, pager })
     }
 
+    /// Return the page number of the current root node. Callers can use this
+    /// after insertions to detect if the root has split.
+    pub fn root_page(&self) -> u32 {
+        self.root_page
+    }
+
     pub fn scan_all_rows(&'a mut self) -> RowCursor<'a> {
         // 1) Find leftmost leaf
         let mut page_num = self.root_page;


### PR DESCRIPTION
## Summary
- expose current root page from `BTree`
- allow mutable access to catalog tables
- keep catalog table metadata in sync when inserts cause root splits

## Testing
- `cargo test -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_6841727c132c8333893a7e63ffa13e09