### PR TITLE
Add WHERE clause parsing and evaluation

### DIFF
--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -7,12 +7,15 @@ pub use plan::PlanNode;
 /// Entry point for executing a plan (stub).
 pub fn execute_plan(plan: PlanNode /*, btree: &mut storage::BTree */) {
     match plan {
-        PlanNode::Insert { key, payload } => {
-            println!("Executing: Insert key={}, payload={}", key, payload);
+        PlanNode::CreateTable { table_name, columns } => {
+            println!("Planning create table {} {:?}", table_name, columns);
+        }
+        PlanNode::Insert { table_name, values } => {
+            println!("Executing: Insert into {} {:?}", table_name, values);
             // In future: btree.insert(key, &payload).unwrap();
         }
-        PlanNode::Select { key } => {
-            println!("Executing: Select key={}", key);
+        PlanNode::Select { table_name, selection } => {
+            println!("Executing: Select from {} where {:?}", table_name, selection);
             // In future: if let Some(row) = btree.find(key).unwrap() { ... }
         }
         PlanNode::Exit => {

--- a/src/execution/plan.rs
+++ b/src/execution/plan.rs
@@ -1,4 +1,4 @@
-use crate::sql::ast::Statement;
+use crate::sql::ast::{Expr, Statement};
 
 #[derive(Debug)]
 pub enum PlanNode {
@@ -12,6 +12,7 @@ pub enum PlanNode {
     },
     Select {
         table_name: String,
+        selection: Option<Expr>,
     },
     Exit,
 }
@@ -24,7 +25,7 @@ pub fn plan_statement(stmt: Statement) -> PlanNode {
         Statement::Insert { table_name, values } => {
             PlanNode::Insert { table_name, values }
         }
-        Statement::Select { table_name } => PlanNode::Select { table_name },
+        Statement::Select { table_name, selection } => PlanNode::Select { table_name, selection },
         Statement::Exit => PlanNode::Exit,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,13 +91,14 @@ fn main() -> io::Result<()> {
                         }
                     }
                 }
-                Statement::Select { table_name } => {
+                Statement::Select { table_name, selection } => {
                     debug!("SELECT * FROM {}", table_name);
 
                     // First, get the table metadata (immutable borrow)
                     match catalog.get_table(&table_name) {
                         Ok(table_info) => {
                             let root_page = table_info.root_page;
+                            let columns = table_info.columns.clone();
                             // Immutable borrow ends here.
 
                             // Now we can borrow `catalog.pager` mutably to scan the table.
@@ -110,8 +111,7 @@ fn main() -> io::Result<()> {
 
                                 println!("-- Contents of table '{}':", table_name);
                                 while let Some(row) = cursor.next() {
-                                    // Deserialize row.payload into Vec<String>
-                                    let bytes = &row.payload[..]; // &[u8]
+                                    let bytes = &row.payload[..];
                                     let mut offset = 0;
                                     let num_cols = u16::from_le_bytes(bytes[offset..offset + 2].try_into().unwrap()) as usize;
                                     offset += 2;
@@ -123,7 +123,17 @@ fn main() -> io::Result<()> {
                                         offset += len;
                                         vals.push(v);
                                     }
-                                    println!("{:?}", vals);
+                                    if selection.is_none() {
+                                        println!("{:?}", vals);
+                                    } else {
+                                        let mut map = std::collections::HashMap::new();
+                                        for (col, val) in columns.iter().zip(vals.iter()) {
+                                            map.insert(col.clone(), val.clone());
+                                        }
+                                        if crate::sql::ast::evaluate_expression(selection.as_ref().unwrap(), &map) {
+                                            println!("{:?}", vals);
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -146,6 +156,7 @@ fn main() -> io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*; // bring Catalog, Pager, BTree, etc. into scope
+    use crate::sql::ast::evaluate_expression;
     use std::fs;
 
     #[test]
@@ -202,5 +213,74 @@ mod tests {
         assert_eq!(rows.len(), 100, "Expected 100 rows in users, got {}", rows.len());
         assert_eq!(rows.first().unwrap().key, 1);
         assert_eq!(rows.last().unwrap().key, 100);
+    }
+
+    #[test]
+    fn select_where_clause() {
+        // Setup new DB
+        let filename = "test_where.db";
+        let _ = fs::remove_file(filename);
+        let mut catalog = Catalog::open(Pager::new(filename).unwrap()).unwrap();
+
+        // Create table and insert a few rows
+        catalog
+            .create_table("users", vec!["id".into(), "name".into()])
+            .unwrap();
+        for i in 1..=3 {
+            let values = vec![i.to_string(), format!("user{}", i)];
+            let mut buf = Vec::new();
+            let col_count = (values.len() as u16).to_le_bytes();
+            buf.extend(&col_count);
+            for v in &values {
+                let vb = v.as_bytes();
+                let len = (vb.len() as u32).to_le_bytes();
+                buf.extend(&len);
+                buf.extend(vb);
+            }
+            let root_page = catalog.get_table("users").unwrap().root_page;
+            let mut table_btree = BTree::open_root(&mut catalog.pager, root_page).unwrap();
+            table_btree.insert(i as i32, &buf[..]).unwrap();
+            let new_root = table_btree.root_page();
+            if new_root != root_page {
+                catalog.get_table_mut("users").unwrap().root_page = new_root;
+            }
+        }
+
+        // Parse select with WHERE
+        let stmt = parse_statement("SELECT * FROM users WHERE name = user2").unwrap();
+        match stmt {
+            Statement::Select { table_name, selection } => {
+                assert_eq!(table_name, "users");
+                assert!(selection.is_some());
+                // Execute simple evaluation of WHERE on all rows
+                let table_info = catalog.get_table(&table_name).unwrap().clone();
+                let root_page = table_info.root_page;
+                let columns = table_info.columns;
+                let mut table_btree = BTree::open_root(&mut catalog.pager, root_page).unwrap();
+                let mut cursor = table_btree.scan_all_rows();
+                let mut found = Vec::new();
+                while let Some(row) = cursor.next() {
+                    // Deserialize row to map
+                    let bytes = &row.payload[..];
+                    let mut offset = 0;
+                    let num_cols = u16::from_le_bytes(bytes[offset..offset + 2].try_into().unwrap()) as usize;
+                    offset += 2;
+                    let mut values = std::collections::HashMap::new();
+                    for col in columns.iter().take(num_cols) {
+                        let len = u32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap()) as usize;
+                        offset += 4;
+                        let v = String::from_utf8_lossy(&bytes[offset..offset + len]).to_string();
+                        offset += len;
+                        values.insert(col.clone(), v);
+                    }
+                    if evaluate_expression(selection.as_ref().unwrap(), &values) {
+                        found.push(row);
+                    }
+                }
+                assert_eq!(found.len(), 1);
+                assert_eq!(found[0].key, 2);
+            }
+            _ => panic!("Expected select statement"),
+        }
     }
 }

--- a/src/sql/ast.rs
+++ b/src/sql/ast.rs
@@ -1,6 +1,14 @@
 // src/sql/ast.rs
 
 #[derive(Debug)]
+pub enum Expr {
+    Equals { left: String, right: String },
+    NotEquals { left: String, right: String },
+    And(Box<Expr>, Box<Expr>),
+    Or(Box<Expr>, Box<Expr>),
+}
+
+#[derive(Debug)]
 pub enum Statement {
     CreateTable {
         table_name: String,
@@ -12,6 +20,25 @@ pub enum Statement {
     },
     Select {
         table_name: String,
+        selection: Option<Expr>,
     },
     Exit,
+}
+
+use std::collections::HashMap;
+
+/// Evaluate an expression against a map of column values. If an operand
+/// matches a column name, the corresponding value is used; otherwise the
+/// operand itself is treated as a literal string.
+pub fn evaluate_expression(expr: &Expr, values: &HashMap<String, String>) -> bool {
+    fn get_value<'a>(token: &'a str, values: &'a HashMap<String, String>) -> &'a str {
+        values.get(token).map(String::as_str).unwrap_or(token)
+    }
+
+    match expr {
+        Expr::Equals { left, right } => get_value(left, values) == get_value(right, values),
+        Expr::NotEquals { left, right } => get_value(left, values) != get_value(right, values),
+        Expr::And(a, b) => evaluate_expression(a, values) && evaluate_expression(b, values),
+        Expr::Or(a, b) => evaluate_expression(a, values) || evaluate_expression(b, values),
+    }
 }


### PR DESCRIPTION
## Summary
- support Boolean expressions for WHERE clause in SQL parser
- extend AST with `Expr` and optional selection for SELECT statements
- implement simple expression evaluation logic
- print SELECT results filtered by WHERE clause
- add tests covering SELECT with WHERE
