### PR TITLE
Add basic LIMIT/OFFSET parsing and bounded scanning

### DIFF
--- a/src/execution/plan.rs
+++ b/src/execution/plan.rs
@@ -1,4 +1,4 @@
-use crate::sql::ast::{Expr, Statement};
+use crate::sql::ast::{Expr, Statement, OrderBy};
 
 #[derive(Debug)]
 pub enum PlanNode {
@@ -15,7 +15,7 @@ pub enum PlanNode {
         selection: Option<Expr>,
         limit: Option<usize>,
         offset: Option<usize>,
-        order_by: bool,
+        order_by: Option<OrderBy>,
     },
     Delete {
         table_name: String,

--- a/src/sql/ast.rs
+++ b/src/sql/ast.rs
@@ -9,6 +9,12 @@ pub enum Expr {
 }
 
 #[derive(Debug)]
+pub struct OrderBy {
+    pub column: String,
+    pub descending: bool,
+}
+
+#[derive(Debug)]
 pub enum Statement {
     CreateTable {
         table_name: String,
@@ -23,7 +29,7 @@ pub enum Statement {
         selection: Option<Expr>,
         limit: Option<usize>,
         offset: Option<usize>,
-        order_by: bool,
+        order_by: Option<OrderBy>,
     },
     Delete {
         table_name: String,

--- a/src/storage/btree.rs
+++ b/src/storage/btree.rs
@@ -907,6 +907,21 @@ impl<'a> BTree<'a> {
         }
     }
 
+    pub fn scan_rows_desc_with_bounds(
+        &'a mut self,
+        skip: usize,
+        limit: Option<usize>,
+    ) -> Vec<Row> {
+        let mut rows: Vec<Row> = self.scan_rows_with_bounds(0, None).collect();
+        rows.reverse();
+        let start = skip.min(rows.len());
+        let end = match limit {
+            Some(l) => start + l.min(rows.len() - start),
+            None => rows.len(),
+        };
+        rows[start..end].to_vec()
+    }
+
     /// Flush all cached pages to disk (for final cleanup).
     pub fn flush_all(&mut self) -> io::Result<()> {
         for i in 0..self.pager.num_pages() {


### PR DESCRIPTION
## Summary
- support LIMIT, OFFSET and ORDER BY clauses in SQL parser
- extend PlanNode and Statement to carry new fields
- add BTree scanning with bounds to implement LIMIT/OFFSET
- update main program and tests
- add unit tests for parser and bounded scan