### PR TITLE
Add UPDATE support

### DIFF
--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -4,7 +4,7 @@ pub mod runtime;
 
 pub use executor::Executor;
 pub use plan::PlanNode;
-pub use runtime::{execute_delete, execute_select_with_indexes, handle_statement};
+pub use runtime::{execute_delete, execute_select_with_indexes, execute_update, handle_statement};
 
 /// Entry point for executing a plan (stub).
 pub fn execute_plan(plan: PlanNode /*, btree: &mut storage::BTree */) {
@@ -32,6 +32,13 @@ pub fn execute_plan(plan: PlanNode /*, btree: &mut storage::BTree */) {
         PlanNode::Delete { table_name, selection } => {
             println!("Executing: Delete from {} where {:?}", table_name, selection);
             // In future: btree.delete(key).unwrap();
+        }
+        PlanNode::Update { table_name, assignments, selection } => {
+            println!(
+                "Executing: Update {} set {:?} where {:?}",
+                table_name, assignments, selection
+            );
+            // Future: btree.update(...)
         }
         PlanNode::Exit => {
             // No action; main loop handles exit.

--- a/src/execution/plan.rs
+++ b/src/execution/plan.rs
@@ -32,6 +32,11 @@ pub enum PlanNode {
         table_name: String,
         selection: Option<Expr>,
     },
+    Update {
+        table_name: String,
+        assignments: Vec<(String, String)>,
+        selection: Option<Expr>,
+    },
     Exit,
 }
 
@@ -57,6 +62,7 @@ pub fn plan_statement(stmt: Statement) -> PlanNode {
         }
         Statement::DropTable { table_name, if_exists } => PlanNode::DropTable { table_name, if_exists },
         Statement::Delete { table_name, selection } => PlanNode::Delete { table_name, selection },
+        Statement::Update { table_name, assignments, selection } => PlanNode::Update { table_name, assignments, selection },
         Statement::Exit => PlanNode::Exit,
     }
 }

--- a/src/sql/ast.rs
+++ b/src/sql/ast.rs
@@ -46,6 +46,11 @@ pub enum Statement {
         table_name: String,
         selection: Option<Expr>,
     },
+    Update {
+        table_name: String,
+        assignments: Vec<(String, String)>,
+        selection: Option<Expr>,
+    },
     Exit,
 }
 


### PR DESCRIPTION
## Summary
- allow parsing and execution of `UPDATE` statements
- update plan and runtime modules to handle new statement
- re-export `execute_update` function
- add unit tests for parsing and executing UPDATE
