### PR TITLE
Add column projection support for SELECT

### DIFF
--- a/tests/select_projection.rs
+++ b/tests/select_projection.rs
@@ -1,0 +1,56 @@
+use aerodb::{catalog::Catalog, storage::pager::Pager, sql::{parser::parse_statement, ast::Statement}, execution::runtime::{select_projection_indices, row_to_strings, format_header}, storage::row::ColumnType};
+use std::fs;
+
+fn setup_catalog(filename: &str) -> Catalog {
+    let _ = fs::remove_file(filename);
+    Catalog::open(Pager::new(filename).unwrap()).unwrap()
+}
+
+#[test]
+fn select_single_column() {
+    let filename = "test_select_single.db";
+    let mut catalog = setup_catalog(filename);
+    aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
+        table_name: "users".into(),
+        columns: vec![("id".into(), ColumnType::Integer), ("name".into(), ColumnType::Text)],
+        fks: Vec::new(),
+        if_not_exists: false,
+    }).unwrap();
+    aerodb::execution::handle_statement(&mut catalog, Statement::Insert { table_name: "users".into(), values: vec!["1".into(), "bob".into()] }).unwrap();
+    let stmt = parse_statement("SELECT name FROM users").unwrap();
+    if let Statement::Select { columns, from_table, .. } = stmt {
+        let info = catalog.get_table(&from_table).unwrap();
+        let (idxs, meta) = select_projection_indices(&info.columns, &columns).unwrap();
+        assert_eq!(format_header(&meta), "name TEXT");
+        let mut rows = Vec::new();
+        aerodb::execution::execute_select_with_indexes(&mut catalog, &from_table, None, &mut rows).unwrap();
+        let vals = row_to_strings(&rows[0]);
+        let proj: Vec<_> = idxs.iter().map(|&i| vals[i].clone()).collect();
+        assert_eq!(proj, vec!["bob"]);
+    } else { panic!("expected select"); }
+}
+
+#[test]
+fn select_two_columns() {
+    let filename = "test_select_two.db";
+    let mut catalog = setup_catalog(filename);
+    aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
+        table_name: "users".into(),
+        columns: vec![("id".into(), ColumnType::Integer), ("name".into(), ColumnType::Text)],
+        fks: Vec::new(),
+        if_not_exists: false,
+    }).unwrap();
+    aerodb::execution::handle_statement(&mut catalog, Statement::Insert { table_name: "users".into(), values: vec!["1".into(), "bob".into()] }).unwrap();
+    let stmt = parse_statement("SELECT id, name FROM users").unwrap();
+    if let Statement::Select { columns, from_table, .. } = stmt {
+        let info = catalog.get_table(&from_table).unwrap();
+        let (idxs, meta) = select_projection_indices(&info.columns, &columns).unwrap();
+        assert_eq!(format_header(&meta), "id INTEGER | name TEXT");
+        let mut rows = Vec::new();
+        aerodb::execution::execute_select_with_indexes(&mut catalog, &from_table, None, &mut rows).unwrap();
+        let vals = row_to_strings(&rows[0]);
+        let proj: Vec<_> = idxs.iter().map(|&i| vals[i].clone()).collect();
+        assert_eq!(proj, vec!["1", "bob"]);
+    } else { panic!("expected select"); }
+}
+


### PR DESCRIPTION
## Summary
- support SELECT column projections in runtime
- add helper utilities for projecting rows
- expand execute_multi_join to handle `*` and new output logic
- create tests for simple column projections