### PR TITLE
Introduce subquery AST and basic parsing

### DIFF
--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -4,7 +4,7 @@ pub mod runtime;
 
 pub use executor::Executor;
 pub use plan::PlanNode;
-pub use runtime::{execute_delete, execute_select_with_indexes, execute_update, handle_statement};
+pub use runtime::{execute_delete, execute_select_with_indexes, execute_update, handle_statement, execute_select_statement};
 
 /// Entry point for executing a plan (stub).
 pub fn execute_plan(plan: PlanNode /*, btree: &mut storage::BTree */) {

--- a/src/execution/plan.rs
+++ b/src/execution/plan.rs
@@ -62,7 +62,7 @@ pub fn plan_statement(stmt: Statement) -> PlanNode {
         }
         Statement::Select { columns, from, joins, where_predicate, group_by: _ } => {
             let table_name = match from.first().unwrap() {
-                crate::sql::ast::TableRef::Named(t) => t.clone(),
+                crate::sql::ast::TableRef::Named { name, .. } => name.clone(),
                 _ => return PlanNode::Select { table_name: String::new(), selection: None, limit: None, offset: None, order_by: None },
             };
             if joins.is_empty() {

--- a/src/execution/plan.rs
+++ b/src/execution/plan.rs
@@ -60,10 +60,14 @@ pub fn plan_statement(stmt: Statement) -> PlanNode {
         Statement::Insert { table_name, values } => {
             PlanNode::Insert { table_name, values }
         }
-        Statement::Select { columns, from_table, joins, where_predicate, group_by: _ } => {
+        Statement::Select { columns, from, joins, where_predicate, group_by: _ } => {
+            let table_name = match from.first().unwrap() {
+                crate::sql::ast::TableRef::Named(t) => t.clone(),
+                _ => return PlanNode::Select { table_name: String::new(), selection: None, limit: None, offset: None, order_by: None },
+            };
             if joins.is_empty() {
                 PlanNode::Select {
-                    table_name: from_table,
+                    table_name,
                     selection: where_predicate,
                     limit: None,
                     offset: None,
@@ -71,7 +75,7 @@ pub fn plan_statement(stmt: Statement) -> PlanNode {
                 }
             } else {
                 PlanNode::MultiJoin(MultiJoinPlan {
-                    base_table: from_table,
+                    base_table: table_name,
                     joins,
                     projections: columns,
                     where_predicate,

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,7 +153,11 @@ mod tests {
         // Parse select with WHERE
         let stmt = parse_statement("SELECT * FROM users WHERE name = user2").unwrap();
         match stmt {
-            Statement::Select { from_table, where_predicate, .. } => {
+            Statement::Select { from, where_predicate, .. } => {
+                let from_table = match from.first().unwrap() {
+                    crate::sql::ast::TableRef::Named(t) => t.clone(),
+                    _ => panic!("expected named table"),
+                };
                 assert_eq!(from_table, "users");
                 assert!(where_predicate.is_some());
                 // Execute simple evaluation of WHERE on all rows
@@ -397,8 +401,10 @@ mod tests {
         let stmt =
             parse_statement("SELECT * FROM nums LIMIT 5 OFFSET 2 ORDER BY id DESC").unwrap();
         match stmt {
-            Statement::Select { from_table, .. } => {
-                assert_eq!(from_table, "nums");
+            Statement::Select { from, .. } => {
+                if let Some(crate::sql::ast::TableRef::Named(t)) = from.first() {
+                    assert_eq!(t, "nums");
+                } else { panic!("expected named table") }
             }
             _ => panic!("Expected select statement"),
         }
@@ -408,24 +414,30 @@ mod tests {
     fn parse_order_by_variants() {
         let stmt = parse_statement("SELECT * FROM users ORDER BY id").unwrap();
         match stmt {
-            Statement::Select { from_table, .. } => {
-                assert_eq!(from_table, "users");
+            Statement::Select { from, .. } => {
+                if let Some(crate::sql::ast::TableRef::Named(t)) = from.first() {
+                    assert_eq!(t, "users");
+                } else { panic!("expected named table") }
             }
             _ => panic!("Expected select"),
         }
 
         let stmt = parse_statement("SELECT * FROM users ORDER BY id ASC").unwrap();
         match stmt {
-            Statement::Select { from_table, .. } => {
-                assert_eq!(from_table, "users");
+            Statement::Select { from, .. } => {
+                if let Some(crate::sql::ast::TableRef::Named(t)) = from.first() {
+                    assert_eq!(t, "users");
+                } else { panic!("expected named table") }
             }
             _ => panic!("Expected select"),
         }
 
         let stmt = parse_statement("SELECT * FROM users ORDER BY id DESC").unwrap();
         match stmt {
-            Statement::Select { from_table, .. } => {
-                assert_eq!(from_table, "users");
+            Statement::Select { from, .. } => {
+                if let Some(crate::sql::ast::TableRef::Named(t)) = from.first() {
+                    assert_eq!(t, "users");
+                } else { panic!("expected named table") }
             }
             _ => panic!("Expected select"),
         }
@@ -596,7 +608,11 @@ mod tests {
 
         let stmt = parse_statement("SELECT * FROM users WHERE name = user2").unwrap();
         match stmt {
-            Statement::Select { from_table: table_name, where_predicate: selection, .. } => {
+            Statement::Select { from, where_predicate: selection, .. } => {
+                let table_name = match from.first().unwrap() {
+                    crate::sql::ast::TableRef::Named(t) => t.clone(),
+                    _ => panic!("expected table"),
+                };
                 let mut results = Vec::new();
                 let used = crate::execution::execute_select_with_indexes(&mut catalog, &table_name, selection, &mut results).unwrap();
                 assert!(used, "index should be used for equality predicate");
@@ -650,7 +666,11 @@ mod tests {
 
         let stmt = parse_statement("SELECT * FROM users WHERE name = user2").unwrap();
         match stmt {
-            Statement::Select { from_table: table_name, where_predicate: selection, .. } => {
+            Statement::Select { from, where_predicate: selection, .. } => {
+                let table_name = match from.first().unwrap() {
+                    crate::sql::ast::TableRef::Named(t) => t.clone(),
+                    _ => panic!("expected named table"),
+                };
                 let mut results = Vec::new();
                 let used = crate::execution::execute_select_with_indexes(&mut catalog, &table_name, selection, &mut results).unwrap();
                 assert!(used, "index should be used on delete check");
@@ -698,7 +718,11 @@ mod tests {
 
         let stmt = parse_statement("SELECT * FROM users WHERE name = dup").unwrap();
         match stmt {
-            Statement::Select { from_table: table_name, where_predicate: selection, .. } => {
+            Statement::Select { from, where_predicate: selection, .. } => {
+                let table_name = match from.first().unwrap() {
+                    crate::sql::ast::TableRef::Named(t) => t.clone(),
+                    _ => panic!("expected named table"),
+                };
                 let mut results = Vec::new();
                 let used = crate::execution::execute_select_with_indexes(&mut catalog, &table_name, selection, &mut results).unwrap();
                 assert!(used, "index should be used for duplicate values");
@@ -744,7 +768,11 @@ mod tests {
 
         let stmt = parse_statement("SELECT * FROM users WHERE id = 1").unwrap();
         match stmt {
-            Statement::Select { from_table: table_name, where_predicate: selection, .. } => {
+            Statement::Select { from, where_predicate: selection, .. } => {
+                let table_name = match from.first().unwrap() {
+                    crate::sql::ast::TableRef::Named(t) => t.clone(),
+                    _ => panic!("expected named table"),
+                };
                 let mut results = Vec::new();
                 let used = crate::execution::execute_select_with_indexes(&mut catalog, &table_name, selection, &mut results).unwrap();
                 assert!(!used, "no index should be used when none defined");
@@ -791,7 +819,11 @@ mod tests {
 
         let stmt = parse_statement("SELECT * FROM users WHERE name != user1").unwrap();
         match stmt {
-            Statement::Select { from_table: table_name, where_predicate: selection, .. } => {
+            Statement::Select { from, where_predicate: selection, .. } => {
+                let table_name = match from.first().unwrap() {
+                    crate::sql::ast::TableRef::Named(t) => t.clone(),
+                    _ => panic!("expected named table"),
+                };
                 let mut results = Vec::new();
                 let used = crate::execution::execute_select_with_indexes(&mut catalog, &table_name, selection, &mut results).unwrap();
                 assert!(!used, "index should not be used for inequality");

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,7 +155,7 @@ mod tests {
         match stmt {
             Statement::Select { from, where_predicate, .. } => {
                 let from_table = match from.first().unwrap() {
-                    crate::sql::ast::TableRef::Named(t) => t.clone(),
+                    crate::sql::ast::TableRef::Named { name, .. } => name.clone(),
                     _ => panic!("expected named table"),
                 };
                 assert_eq!(from_table, "users");
@@ -402,8 +402,8 @@ mod tests {
             parse_statement("SELECT * FROM nums LIMIT 5 OFFSET 2 ORDER BY id DESC").unwrap();
         match stmt {
             Statement::Select { from, .. } => {
-                if let Some(crate::sql::ast::TableRef::Named(t)) = from.first() {
-                    assert_eq!(t, "nums");
+                if let Some(crate::sql::ast::TableRef::Named { name, .. }) = from.first() {
+                    assert_eq!(name, "nums");
                 } else { panic!("expected named table") }
             }
             _ => panic!("Expected select statement"),
@@ -415,8 +415,8 @@ mod tests {
         let stmt = parse_statement("SELECT * FROM users ORDER BY id").unwrap();
         match stmt {
             Statement::Select { from, .. } => {
-                if let Some(crate::sql::ast::TableRef::Named(t)) = from.first() {
-                    assert_eq!(t, "users");
+                if let Some(crate::sql::ast::TableRef::Named { name, .. }) = from.first() {
+                    assert_eq!(name, "users");
                 } else { panic!("expected named table") }
             }
             _ => panic!("Expected select"),
@@ -425,8 +425,8 @@ mod tests {
         let stmt = parse_statement("SELECT * FROM users ORDER BY id ASC").unwrap();
         match stmt {
             Statement::Select { from, .. } => {
-                if let Some(crate::sql::ast::TableRef::Named(t)) = from.first() {
-                    assert_eq!(t, "users");
+                if let Some(crate::sql::ast::TableRef::Named { name, .. }) = from.first() {
+                    assert_eq!(name, "users");
                 } else { panic!("expected named table") }
             }
             _ => panic!("Expected select"),
@@ -435,8 +435,8 @@ mod tests {
         let stmt = parse_statement("SELECT * FROM users ORDER BY id DESC").unwrap();
         match stmt {
             Statement::Select { from, .. } => {
-                if let Some(crate::sql::ast::TableRef::Named(t)) = from.first() {
-                    assert_eq!(t, "users");
+                if let Some(crate::sql::ast::TableRef::Named { name, .. }) = from.first() {
+                    assert_eq!(name, "users");
                 } else { panic!("expected named table") }
             }
             _ => panic!("Expected select"),
@@ -610,7 +610,7 @@ mod tests {
         match stmt {
             Statement::Select { from, where_predicate: selection, .. } => {
                 let table_name = match from.first().unwrap() {
-                    crate::sql::ast::TableRef::Named(t) => t.clone(),
+                    crate::sql::ast::TableRef::Named { name, .. } => name.clone(),
                     _ => panic!("expected table"),
                 };
                 let mut results = Vec::new();
@@ -668,7 +668,7 @@ mod tests {
         match stmt {
             Statement::Select { from, where_predicate: selection, .. } => {
                 let table_name = match from.first().unwrap() {
-                    crate::sql::ast::TableRef::Named(t) => t.clone(),
+                    crate::sql::ast::TableRef::Named { name, .. } => name.clone(),
                     _ => panic!("expected named table"),
                 };
                 let mut results = Vec::new();
@@ -720,7 +720,7 @@ mod tests {
         match stmt {
             Statement::Select { from, where_predicate: selection, .. } => {
                 let table_name = match from.first().unwrap() {
-                    crate::sql::ast::TableRef::Named(t) => t.clone(),
+                    crate::sql::ast::TableRef::Named { name, .. } => name.clone(),
                     _ => panic!("expected named table"),
                 };
                 let mut results = Vec::new();
@@ -770,7 +770,7 @@ mod tests {
         match stmt {
             Statement::Select { from, where_predicate: selection, .. } => {
                 let table_name = match from.first().unwrap() {
-                    crate::sql::ast::TableRef::Named(t) => t.clone(),
+                    crate::sql::ast::TableRef::Named { name, .. } => name.clone(),
                     _ => panic!("expected named table"),
                 };
                 let mut results = Vec::new();
@@ -821,7 +821,7 @@ mod tests {
         match stmt {
             Statement::Select { from, where_predicate: selection, .. } => {
                 let table_name = match from.first().unwrap() {
-                    crate::sql::ast::TableRef::Named(t) => t.clone(),
+                    crate::sql::ast::TableRef::Named { name, .. } => name.clone(),
                     _ => panic!("expected named table"),
                 };
                 let mut results = Vec::new();

--- a/src/sql/ast.rs
+++ b/src/sql/ast.rs
@@ -75,6 +75,7 @@ pub enum SelectExpr {
     Column(String),
     Aggregate { func: AggFunc, column: Option<String> },
     Subquery(Box<Statement>),
+    Literal(String),
 }
 pub type Predicate = Expr;
 

--- a/src/sql/ast.rs
+++ b/src/sql/ast.rs
@@ -7,6 +7,7 @@ pub enum Expr {
     NotEquals { left: String, right: String },
     And(Box<Expr>, Box<Expr>),
     Or(Box<Expr>, Box<Expr>),
+    Subquery(Box<Statement>),
 }
 
 #[derive(Debug)]
@@ -40,6 +41,12 @@ pub struct JoinClause {
 }
 
 #[derive(Debug, Clone)]
+pub enum TableRef {
+    Named(String),
+    Subquery { query: Box<Statement>, alias: String },
+}
+
+#[derive(Debug, Clone)]
 pub enum AggFunc {
     Min,
     Max,
@@ -65,10 +72,11 @@ pub enum SelectExpr {
     All,
     Column(String),
     Aggregate { func: AggFunc, column: Option<String> },
+    Subquery(Box<Statement>),
 }
 pub type Predicate = Expr;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Statement {
     CreateTable {
         table_name: String,
@@ -91,7 +99,7 @@ pub enum Statement {
     },
     Select {
         columns: Vec<SelectExpr>,
-        from_table: String,
+        from: Vec<TableRef>,
         joins: Vec<JoinClause>,
         where_predicate: Option<Predicate>,
         group_by: Option<Vec<String>>,
@@ -126,5 +134,6 @@ pub fn evaluate_expression(expr: &Expr, values: &HashMap<String, String>) -> boo
         Expr::NotEquals { left, right } => get_value(left, values) != get_value(right, values),
         Expr::And(a, b) => evaluate_expression(a, values) && evaluate_expression(b, values),
         Expr::Or(a, b) => evaluate_expression(a, values) || evaluate_expression(b, values),
+        Expr::Subquery(_) => false,
     }
 }

--- a/src/sql/ast.rs
+++ b/src/sql/ast.rs
@@ -6,6 +6,7 @@ pub enum Expr {
     Equals { left: String, right: String },
     NotEquals { left: String, right: String },
     InSubquery { left: String, query: Box<Statement> },
+    ExistsSubquery { query: Box<Statement> },
     And(Box<Expr>, Box<Expr>),
     Or(Box<Expr>, Box<Expr>),
     Subquery(Box<Statement>),
@@ -43,7 +44,7 @@ pub struct JoinClause {
 
 #[derive(Debug, Clone)]
 pub enum TableRef {
-    Named(String),
+    Named { name: String, alias: Option<String> },
     Subquery { query: Box<Statement>, alias: String },
 }
 
@@ -133,7 +134,7 @@ pub fn evaluate_expression(expr: &Expr, values: &HashMap<String, String>) -> boo
     match expr {
         Expr::Equals { left, right } => get_value(left, values) == get_value(right, values),
         Expr::NotEquals { left, right } => get_value(left, values) != get_value(right, values),
-        Expr::InSubquery { .. } => false,
+        Expr::InSubquery { .. } | Expr::ExistsSubquery { .. } => false,
         Expr::And(a, b) => evaluate_expression(a, values) && evaluate_expression(b, values),
         Expr::Or(a, b) => evaluate_expression(a, values) || evaluate_expression(b, values),
         Expr::Subquery(_) => false,

--- a/src/sql/ast.rs
+++ b/src/sql/ast.rs
@@ -5,6 +5,7 @@ use crate::storage::row::ColumnType;
 pub enum Expr {
     Equals { left: String, right: String },
     NotEquals { left: String, right: String },
+    InSubquery { left: String, query: Box<Statement> },
     And(Box<Expr>, Box<Expr>),
     Or(Box<Expr>, Box<Expr>),
     Subquery(Box<Statement>),
@@ -132,6 +133,7 @@ pub fn evaluate_expression(expr: &Expr, values: &HashMap<String, String>) -> boo
     match expr {
         Expr::Equals { left, right } => get_value(left, values) == get_value(right, values),
         Expr::NotEquals { left, right } => get_value(left, values) != get_value(right, values),
+        Expr::InSubquery { .. } => false,
         Expr::And(a, b) => evaluate_expression(a, values) && evaluate_expression(b, values),
         Expr::Or(a, b) => evaluate_expression(a, values) || evaluate_expression(b, values),
         Expr::Subquery(_) => false,

--- a/src/sql/parser.rs
+++ b/src/sql/parser.rs
@@ -300,6 +300,10 @@ pub fn parse_statement(input: &str) -> Result<Statement, String> {
                 } else if upper.starts_with("MAX(") {
                     let inner = token[4..token.len() - 1].trim().to_string();
                     columns.push(crate::sql::ast::SelectExpr::Aggregate { func: crate::sql::ast::AggFunc::Max, column: Some(inner) });
+                } else if token.starts_with("'") && token.ends_with("'") {
+                    columns.push(crate::sql::ast::SelectExpr::Literal(token[1..token.len()-1].to_string()));
+                } else if token.chars().all(|c| c.is_ascii_digit()) {
+                    columns.push(crate::sql::ast::SelectExpr::Literal(token.to_string()));
                 } else {
                     columns.push(crate::sql::ast::SelectExpr::Column(token.to_string()));
                 }

--- a/tests/aggregate.rs
+++ b/tests/aggregate.rs
@@ -22,7 +22,7 @@ fn basic_count() {
     let stmt = parse_statement("SELECT COUNT(*) FROM employees").unwrap();
     if let Statement::Select { columns, from, group_by, .. } = stmt {
         let table = match from.first().unwrap() {
-            aerodb::sql::ast::TableRef::Named(t) => t,
+            aerodb::sql::ast::TableRef::Named { name, .. } => name,
             _ => panic!("expected table"),
         };
         let mut out = Vec::new();
@@ -53,7 +53,7 @@ fn simple_grouping() {
     let stmt = parse_statement("SELECT department, COUNT(*) FROM employees GROUP BY department").unwrap();
     if let Statement::Select { columns, from, group_by, .. } = stmt {
         let table = match from.first().unwrap() {
-            aerodb::sql::ast::TableRef::Named(t) => t,
+            aerodb::sql::ast::TableRef::Named { name, .. } => name,
             _ => panic!("expected table"),
         };
         let mut out = Vec::new();

--- a/tests/aggregate.rs
+++ b/tests/aggregate.rs
@@ -20,9 +20,13 @@ fn basic_count() {
         aerodb::execution::handle_statement(&mut catalog, Statement::Insert { table_name: "employees".into(), values: vec![i.to_string()] }).unwrap();
     }
     let stmt = parse_statement("SELECT COUNT(*) FROM employees").unwrap();
-    if let Statement::Select { columns, from_table, group_by, .. } = stmt {
+    if let Statement::Select { columns, from, group_by, .. } = stmt {
+        let table = match from.first().unwrap() {
+            aerodb::sql::ast::TableRef::Named(t) => t,
+            _ => panic!("expected table"),
+        };
         let mut out = Vec::new();
-        let header = aerodb::execution::runtime::execute_group_query(&mut catalog, &from_table, &columns, group_by.as_deref(), None, &mut out).unwrap();
+        let header = aerodb::execution::runtime::execute_group_query(&mut catalog, table, &columns, group_by.as_deref(), None, &mut out).unwrap();
         assert_eq!(format_header(&header), "COUNT(*) INTEGER");
         assert_eq!(out, vec![vec!["3".to_string()]]);
     } else { panic!("expected select"); }
@@ -47,9 +51,13 @@ fn simple_grouping() {
         aerodb::execution::handle_statement(&mut catalog, Statement::Insert { table_name: "employees".into(), values: vec![id.to_string(), dep.into()] }).unwrap();
     }
     let stmt = parse_statement("SELECT department, COUNT(*) FROM employees GROUP BY department").unwrap();
-    if let Statement::Select { columns, from_table, group_by, .. } = stmt {
+    if let Statement::Select { columns, from, group_by, .. } = stmt {
+        let table = match from.first().unwrap() {
+            aerodb::sql::ast::TableRef::Named(t) => t,
+            _ => panic!("expected table"),
+        };
         let mut out = Vec::new();
-        let header = aerodb::execution::runtime::execute_group_query(&mut catalog, &from_table, &columns, group_by.as_deref(), None, &mut out).unwrap();
+        let header = aerodb::execution::runtime::execute_group_query(&mut catalog, table, &columns, group_by.as_deref(), None, &mut out).unwrap();
         assert_eq!(format_header(&header), "department TEXT | COUNT(*) INTEGER");
         out.sort();
         assert_eq!(out, vec![vec!["d1".to_string(), "2".to_string()], vec!["d2".to_string(), "1".to_string()]]);

--- a/tests/aggregate.rs
+++ b/tests/aggregate.rs
@@ -26,7 +26,7 @@ fn basic_count() {
             _ => panic!("expected table"),
         };
         let mut out = Vec::new();
-        let header = aerodb::execution::runtime::execute_group_query(&mut catalog, table, &columns, group_by.as_deref(), None, &mut out).unwrap();
+        let header = aerodb::execution::runtime::execute_group_query(&mut catalog, table, &columns, group_by.as_deref(), None, &mut out, None).unwrap();
         assert_eq!(format_header(&header), "COUNT(*) INTEGER");
         assert_eq!(out, vec![vec!["3".to_string()]]);
     } else { panic!("expected select"); }
@@ -57,7 +57,7 @@ fn simple_grouping() {
             _ => panic!("expected table"),
         };
         let mut out = Vec::new();
-        let header = aerodb::execution::runtime::execute_group_query(&mut catalog, table, &columns, group_by.as_deref(), None, &mut out).unwrap();
+        let header = aerodb::execution::runtime::execute_group_query(&mut catalog, table, &columns, group_by.as_deref(), None, &mut out, None).unwrap();
         assert_eq!(format_header(&header), "department TEXT | COUNT(*) INTEGER");
         out.sort();
         assert_eq!(out, vec![vec!["d1".to_string(), "2".to_string()], vec!["d2".to_string(), "1".to_string()]]);

--- a/tests/multi_join.rs
+++ b/tests/multi_join.rs
@@ -38,8 +38,9 @@ fn join_two_tables() {
     }
 
     let stmt = parse_statement("SELECT a.v, b.w FROM a JOIN b ON a.id = b.a_id").unwrap();
-    if let Statement::Select { columns, from_table, joins, where_predicate, .. } = stmt {
-        let plan = aerodb::execution::plan::MultiJoinPlan { base_table: from_table, joins, projections: columns, where_predicate };
+    if let Statement::Select { columns, from, joins, where_predicate, .. } = stmt {
+        let base_table = match from.first().unwrap() { aerodb::sql::ast::TableRef::Named(t) => t.clone(), _ => panic!("expected table") };
+        let plan = aerodb::execution::plan::MultiJoinPlan { base_table, joins, projections: columns, where_predicate };
         let mut results = Vec::new();
         execute_multi_join(&plan, &mut catalog, &mut results).unwrap();
         assert_eq!(results.len(), 3);
@@ -61,8 +62,9 @@ fn join_three_tables() {
     aerodb::execution::handle_statement(&mut catalog, Statement::Insert { table_name: "c".into(), values: vec!["1".into(), "1".into(), "cx1".into()] }).unwrap();
     aerodb::execution::handle_statement(&mut catalog, Statement::Insert { table_name: "c".into(), values: vec!["2".into(), "3".into(), "cx2".into()] }).unwrap();
     let stmt = parse_statement("SELECT a.v, b.w, c.x FROM a JOIN b ON a.id = b.a_id JOIN c ON b.id = c.b_id").unwrap();
-    if let Statement::Select { columns, from_table, joins, where_predicate, .. } = stmt {
-        let plan = aerodb::execution::plan::MultiJoinPlan { base_table: from_table, joins, projections: columns, where_predicate };
+    if let Statement::Select { columns, from, joins, where_predicate, .. } = stmt {
+        let base_table = match from.first().unwrap() { aerodb::sql::ast::TableRef::Named(t) => t.clone(), _ => panic!("expected table") };
+        let plan = aerodb::execution::plan::MultiJoinPlan { base_table, joins, projections: columns, where_predicate };
         let mut results = Vec::new();
         execute_multi_join(&plan, &mut catalog, &mut results).unwrap();
         assert_eq!(results.len(), 2);
@@ -81,8 +83,9 @@ fn join_with_where() {
     aerodb::execution::handle_statement(&mut catalog, Statement::Insert { table_name: "b".into(), values: vec!["1".into(), "1".into(), "bw1".into()] }).unwrap();
     aerodb::execution::handle_statement(&mut catalog, Statement::Insert { table_name: "b".into(), values: vec!["2".into(), "2".into(), "bw2".into()] }).unwrap();
     let stmt = parse_statement("SELECT a.v, b.w FROM a JOIN b ON a.id = b.a_id WHERE a.v = av1").unwrap();
-    if let Statement::Select { columns, from_table, joins, where_predicate, .. } = stmt {
-        let plan = aerodb::execution::plan::MultiJoinPlan { base_table: from_table, joins, projections: columns, where_predicate };
+    if let Statement::Select { columns, from, joins, where_predicate, .. } = stmt {
+        let base_table = match from.first().unwrap() { aerodb::sql::ast::TableRef::Named(t) => t.clone(), _ => panic!("expected table") };
+        let plan = aerodb::execution::plan::MultiJoinPlan { base_table, joins, projections: columns, where_predicate };
         let mut results = Vec::new();
         execute_multi_join(&plan, &mut catalog, &mut results).unwrap();
         assert_eq!(results.len(), 1);

--- a/tests/multi_join.rs
+++ b/tests/multi_join.rs
@@ -39,7 +39,7 @@ fn join_two_tables() {
 
     let stmt = parse_statement("SELECT a.v, b.w FROM a JOIN b ON a.id = b.a_id").unwrap();
     if let Statement::Select { columns, from, joins, where_predicate, .. } = stmt {
-        let base_table = match from.first().unwrap() { aerodb::sql::ast::TableRef::Named(t) => t.clone(), _ => panic!("expected table") };
+        let base_table = match from.first().unwrap() { aerodb::sql::ast::TableRef::Named { name, .. } => name.clone(), _ => panic!("expected table") };
         let plan = aerodb::execution::plan::MultiJoinPlan { base_table, joins, projections: columns, where_predicate };
         let mut results = Vec::new();
         execute_multi_join(&plan, &mut catalog, &mut results).unwrap();
@@ -63,7 +63,7 @@ fn join_three_tables() {
     aerodb::execution::handle_statement(&mut catalog, Statement::Insert { table_name: "c".into(), values: vec!["2".into(), "3".into(), "cx2".into()] }).unwrap();
     let stmt = parse_statement("SELECT a.v, b.w, c.x FROM a JOIN b ON a.id = b.a_id JOIN c ON b.id = c.b_id").unwrap();
     if let Statement::Select { columns, from, joins, where_predicate, .. } = stmt {
-        let base_table = match from.first().unwrap() { aerodb::sql::ast::TableRef::Named(t) => t.clone(), _ => panic!("expected table") };
+        let base_table = match from.first().unwrap() { aerodb::sql::ast::TableRef::Named { name, .. } => name.clone(), _ => panic!("expected table") };
         let plan = aerodb::execution::plan::MultiJoinPlan { base_table, joins, projections: columns, where_predicate };
         let mut results = Vec::new();
         execute_multi_join(&plan, &mut catalog, &mut results).unwrap();
@@ -84,7 +84,7 @@ fn join_with_where() {
     aerodb::execution::handle_statement(&mut catalog, Statement::Insert { table_name: "b".into(), values: vec!["2".into(), "2".into(), "bw2".into()] }).unwrap();
     let stmt = parse_statement("SELECT a.v, b.w FROM a JOIN b ON a.id = b.a_id WHERE a.v = av1").unwrap();
     if let Statement::Select { columns, from, joins, where_predicate, .. } = stmt {
-        let base_table = match from.first().unwrap() { aerodb::sql::ast::TableRef::Named(t) => t.clone(), _ => panic!("expected table") };
+        let base_table = match from.first().unwrap() { aerodb::sql::ast::TableRef::Named { name, .. } => name.clone(), _ => panic!("expected table") };
         let plan = aerodb::execution::plan::MultiJoinPlan { base_table, joins, projections: columns, where_predicate };
         let mut results = Vec::new();
         execute_multi_join(&plan, &mut catalog, &mut results).unwrap();

--- a/tests/nested_queries.rs
+++ b/tests/nested_queries.rs
@@ -1,0 +1,11 @@
+use aerodb::sql::{parser::parse_statement, ast::{Statement, TableRef, SelectExpr}};
+
+#[test]
+fn parse_from_subquery() {
+    let stmt = parse_statement("SELECT * FROM (SELECT id FROM t1) AS sub").unwrap();
+    if let Statement::Select { from, .. } = stmt {
+        assert!(matches!(from[0], TableRef::Subquery { .. }));
+    } else { panic!("expected select"); }
+}
+
+// TODO: support subquery parsing in SELECT list

--- a/tests/nested_queries.rs
+++ b/tests/nested_queries.rs
@@ -41,3 +41,48 @@ fn execute_from_subquery_simple() {
         assert_eq!(out, vec![vec![String::from("1")], vec![String::from("2")]]);
     } else { panic!("expected select"); }
 }
+
+#[test]
+fn parse_where_in_subquery() {
+    let stmt = parse_statement("SELECT id FROM users WHERE id IN (SELECT id FROM admins)").unwrap();
+    if let Statement::Select { where_predicate: Some(pred), .. } = stmt {
+        match pred {
+            aerodb::sql::ast::Expr::InSubquery { ref left, .. } => assert_eq!(left, "id"),
+            _ => panic!("expected InSubquery"),
+        }
+    } else { panic!("expected select with predicate"); }
+}
+
+#[test]
+fn execute_where_in_subquery() {
+    let filename = "test_where_in_subquery.db";
+    let mut catalog = setup_catalog(filename);
+    aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
+        table_name: "users".into(),
+        columns: vec![("id".into(), ColumnType::Integer)],
+        fks: Vec::new(),
+        if_not_exists: false,
+    }).unwrap();
+    aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
+        table_name: "admins".into(),
+        columns: vec![("id".into(), ColumnType::Integer)],
+        fks: Vec::new(),
+        if_not_exists: false,
+    }).unwrap();
+    for id in 1..=3 {
+        aerodb::execution::handle_statement(&mut catalog, Statement::Insert { table_name: "users".into(), values: vec![id.to_string()] }).unwrap();
+    }
+    for id in [2,3] {
+        aerodb::execution::handle_statement(&mut catalog, Statement::Insert { table_name: "admins".into(), values: vec![id.to_string()] }).unwrap();
+    }
+
+    let stmt = parse_statement("SELECT id FROM users WHERE id IN (SELECT id FROM admins)").unwrap();
+    if let Statement::Select { .. } = stmt {
+        let mut out = Vec::new();
+        let header = execute_select_statement(&mut catalog, &stmt, &mut out).unwrap();
+        assert_eq!(format_header(&header), "id INTEGER");
+        out.sort();
+        assert_eq!(out, vec![vec!["2".to_string()], vec!["3".to_string()]]);
+    } else { panic!("expected select"); }
+}
+

--- a/tests/nested_queries.rs
+++ b/tests/nested_queries.rs
@@ -35,7 +35,7 @@ fn execute_from_subquery_simple() {
     let stmt = parse_statement("SELECT * FROM (SELECT id FROM t1) AS sub").unwrap();
     if let Statement::Select { .. } = stmt {
         let mut out = Vec::new();
-        let header = execute_select_statement(&mut catalog, &stmt, &mut out).unwrap();
+        let header = execute_select_statement(&mut catalog, &stmt, &mut out, None).unwrap();
         assert_eq!(format_header(&header), "id INTEGER");
         out.sort();
         assert_eq!(out, vec![vec![String::from("1")], vec![String::from("2")]]);
@@ -79,10 +79,57 @@ fn execute_where_in_subquery() {
     let stmt = parse_statement("SELECT id FROM users WHERE id IN (SELECT id FROM admins)").unwrap();
     if let Statement::Select { .. } = stmt {
         let mut out = Vec::new();
-        let header = execute_select_statement(&mut catalog, &stmt, &mut out).unwrap();
+        let header = execute_select_statement(&mut catalog, &stmt, &mut out, None).unwrap();
         assert_eq!(format_header(&header), "id INTEGER");
         out.sort();
         assert_eq!(out, vec![vec!["2".to_string()], vec!["3".to_string()]]);
     } else { panic!("expected select"); }
+}
+
+
+#[test]
+fn parse_exists_subquery() {
+    let stmt = parse_statement("SELECT name FROM users WHERE EXISTS (SELECT user_id FROM orders WHERE orders.user_id = users.id)").unwrap();
+    if let Statement::Select { where_predicate: Some(pred), .. } = stmt {
+        if !matches!(pred, aerodb::sql::ast::Expr::ExistsSubquery { .. }) {
+            panic!("expected ExistsSubquery");
+        }
+    } else {
+        panic!("expected select with predicate");
+    }
+}
+
+#[test]
+fn execute_exists_correlated() {
+    let filename = "test_exists_correlated.db";
+    let mut catalog = setup_catalog(filename);
+    aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
+        table_name: "users".into(),
+        columns: vec![("id".into(), ColumnType::Integer), ("name".into(), ColumnType::Text)],
+        fks: Vec::new(),
+        if_not_exists: false,
+    }).unwrap();
+    aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
+        table_name: "orders".into(),
+        columns: vec![("id".into(), ColumnType::Integer), ("user_id".into(), ColumnType::Integer), ("product".into(), ColumnType::Text)],
+        fks: Vec::new(),
+        if_not_exists: false,
+    }).unwrap();
+    aerodb::execution::handle_statement(&mut catalog, Statement::Insert { table_name: "users".into(), values: vec!["1".into(), "Alice".into()] }).unwrap();
+    aerodb::execution::handle_statement(&mut catalog, Statement::Insert { table_name: "users".into(), values: vec!["2".into(), "Bob".into()] }).unwrap();
+    aerodb::execution::handle_statement(&mut catalog, Statement::Insert { table_name: "users".into(), values: vec!["3".into(), "Cason".into()] }).unwrap();
+    aerodb::execution::handle_statement(&mut catalog, Statement::Insert { table_name: "orders".into(), values: vec!["10".into(), "1".into(), "Widget".into()] }).unwrap();
+    aerodb::execution::handle_statement(&mut catalog, Statement::Insert { table_name: "orders".into(), values: vec!["11".into(), "2".into(), "Phone".into()] }).unwrap();
+
+    let stmt = parse_statement("SELECT name FROM users WHERE EXISTS (SELECT user_id FROM orders WHERE orders.user_id = users.id)").unwrap();
+    if let Statement::Select { .. } = stmt {
+        let mut out = Vec::new();
+        let header = execute_select_statement(&mut catalog, &stmt, &mut out, None).unwrap();
+        assert_eq!(format_header(&header), "name TEXT");
+        out.sort();
+        assert_eq!(out, vec![vec!["Alice".to_string()], vec!["Bob".to_string()]]);
+    } else {
+        panic!("expected select");
+    }
 }
 

--- a/tests/nested_queries.rs
+++ b/tests/nested_queries.rs
@@ -9,3 +9,35 @@ fn parse_from_subquery() {
 }
 
 // TODO: support subquery parsing in SELECT list
+
+use aerodb::{catalog::Catalog, storage::pager::Pager, execution::runtime::{execute_select_statement, format_header}};
+use aerodb::storage::row::ColumnType;
+use std::fs;
+
+fn setup_catalog(filename: &str) -> Catalog {
+    let _ = fs::remove_file(filename);
+    Catalog::open(Pager::new(filename).unwrap()).unwrap()
+}
+
+#[test]
+fn execute_from_subquery_simple() {
+    let filename = "test_from_subquery_exec.db";
+    let mut catalog = setup_catalog(filename);
+    aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
+        table_name: "t1".into(),
+        columns: vec![("id".into(), ColumnType::Integer)],
+        fks: Vec::new(),
+        if_not_exists: false,
+    }).unwrap();
+    aerodb::execution::handle_statement(&mut catalog, Statement::Insert { table_name: "t1".into(), values: vec!["1".into()] }).unwrap();
+    aerodb::execution::handle_statement(&mut catalog, Statement::Insert { table_name: "t1".into(), values: vec!["2".into()] }).unwrap();
+
+    let stmt = parse_statement("SELECT * FROM (SELECT id FROM t1) AS sub").unwrap();
+    if let Statement::Select { .. } = stmt {
+        let mut out = Vec::new();
+        let header = execute_select_statement(&mut catalog, &stmt, &mut out).unwrap();
+        assert_eq!(format_header(&header), "id INTEGER");
+        out.sort();
+        assert_eq!(out, vec![vec![String::from("1")], vec![String::from("2")]]);
+    } else { panic!("expected select"); }
+}

--- a/tests/select_projection.rs
+++ b/tests/select_projection.rs
@@ -19,7 +19,7 @@ fn select_single_column() {
     aerodb::execution::handle_statement(&mut catalog, Statement::Insert { table_name: "users".into(), values: vec!["1".into(), "bob".into()] }).unwrap();
     let stmt = parse_statement("SELECT name FROM users").unwrap();
     if let Statement::Select { columns, from, .. } = stmt {
-        let table = match from.first().unwrap() { aerodb::sql::ast::TableRef::Named(t) => t, _ => panic!("expected table") };
+        let table = match from.first().unwrap() { aerodb::sql::ast::TableRef::Named { name, .. } => name, _ => panic!("expected table") };
         let info = catalog.get_table(table).unwrap();
         let (idxs, meta) = select_projection_indices(&info.columns, &columns).unwrap();
         assert_eq!(format_header(&meta), "name TEXT");
@@ -44,7 +44,7 @@ fn select_two_columns() {
     aerodb::execution::handle_statement(&mut catalog, Statement::Insert { table_name: "users".into(), values: vec!["1".into(), "bob".into()] }).unwrap();
     let stmt = parse_statement("SELECT id, name FROM users").unwrap();
     if let Statement::Select { columns, from, .. } = stmt {
-        let table = match from.first().unwrap() { aerodb::sql::ast::TableRef::Named(t) => t, _ => panic!("expected table") };
+        let table = match from.first().unwrap() { aerodb::sql::ast::TableRef::Named { name, .. } => name, _ => panic!("expected table") };
         let info = catalog.get_table(table).unwrap();
         let (idxs, meta) = select_projection_indices(&info.columns, &columns).unwrap();
         assert_eq!(format_header(&meta), "id INTEGER | name TEXT");

--- a/tests/select_projection.rs
+++ b/tests/select_projection.rs
@@ -31,6 +31,7 @@ fn select_single_column() {
             .map(|p| match p {
                 aerodb::execution::runtime::Projection::Index(i) => vals[*i].clone(),
                 aerodb::execution::runtime::Projection::Literal(s) => s.clone(),
+                aerodb::execution::runtime::Projection::Subquery(_) => String::new(),
             })
             .collect();
         assert_eq!(proj, vec!["bob"]);
@@ -62,6 +63,7 @@ fn select_two_columns() {
             .map(|p| match p {
                 aerodb::execution::runtime::Projection::Index(i) => vals[*i].clone(),
                 aerodb::execution::runtime::Projection::Literal(s) => s.clone(),
+                aerodb::execution::runtime::Projection::Subquery(_) => String::new(),
             })
             .collect();
         assert_eq!(proj, vec!["1", "bob"]);


### PR DESCRIPTION
## Summary
- add new `Expr::Subquery`, `TableRef`, and extend `SelectExpr`
- adjust `Statement::Select` to support `from: Vec<TableRef>`
- implement minimal subquery handling in parser
- update plan and runtime stubs for new AST
- adapt existing tests and add `nested_queries` parser test