### PR TITLE
Add DEFAULT clause support

### DIFF
--- a/src/execution/plan.rs
+++ b/src/execution/plan.rs
@@ -1,11 +1,12 @@
 use crate::sql::ast::{Expr, Statement, OrderBy, JoinClause, SelectExpr, Predicate};
 use crate::storage::row::ColumnType;
+use crate::sql::ast::ColumnDef;
 
 #[derive(Debug)]
 pub enum PlanNode {
     CreateTable {
         table_name: String,
-        columns: Vec<(String, ColumnType, bool)>,
+        columns: Vec<ColumnDef>,
         if_not_exists: bool,
     },
     CreateIndex {

--- a/src/sql/ast.rs
+++ b/src/sql/ast.rs
@@ -61,6 +61,17 @@ pub enum AggFunc {
     Avg,
 }
 
+/// SQL literal used in DEFAULT clauses and elsewhere.
+pub type Literal = String;
+
+#[derive(Debug, Clone)]
+pub struct ColumnDef {
+    pub name: String,
+    pub col_type: ColumnType,
+    pub not_null: bool,
+    pub default_value: Option<Literal>,
+}
+
 impl AggFunc {
     pub fn as_str(&self) -> &'static str {
         match self {
@@ -87,7 +98,7 @@ pub type Predicate = Expr;
 pub enum Statement {
     CreateTable {
         table_name: String,
-        columns: Vec<(String, ColumnType, bool)>,
+        columns: Vec<ColumnDef>,
         fks: Vec<ForeignKey>,
         if_not_exists: bool,
     },

--- a/tests/aggregate.rs
+++ b/tests/aggregate.rs
@@ -12,7 +12,9 @@ fn basic_count() {
     let mut catalog = setup_catalog(filename);
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "employees".into(),
-        columns: vec![("id".into(), ColumnType::Integer, false)],
+        columns: vec![
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None }
+        ],
         fks: Vec::new(),
         if_not_exists: false,
     }).unwrap();
@@ -39,8 +41,8 @@ fn simple_grouping() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "employees".into(),
         columns: vec![
-            ("id".into(), ColumnType::Integer, false),
-            ("department".into(), ColumnType::Text, false),
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "department".into(), col_type: ColumnType::Text, not_null: false, default_value: None },
         ],
         fks: Vec::new(),
         if_not_exists: false,

--- a/tests/char_type.rs
+++ b/tests/char_type.rs
@@ -13,8 +13,8 @@ fn char_column_basic() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "items".into(),
         columns: vec![
-            ("id".into(), ColumnType::Integer, false),
-            ("code".into(), ColumnType::Char(3), false),
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "code".into(), col_type: ColumnType::Char(3), not_null: false, default_value: None },
         ],
         fks: Vec::new(),
         if_not_exists: false,
@@ -41,8 +41,8 @@ fn char_column_validate_length() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "items".into(),
         columns: vec![
-            ("id".into(), ColumnType::Integer, false),
-            ("code".into(), ColumnType::Char(3), false),
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "code".into(), col_type: ColumnType::Char(3), not_null: false, default_value: None },
         ],
         fks: Vec::new(),
         if_not_exists: false,

--- a/tests/default_values.rs
+++ b/tests/default_values.rs
@@ -1,0 +1,30 @@
+use aerodb::{catalog::Catalog, storage::pager::Pager, execution::runtime::{handle_statement, execute_select_with_indexes}, sql::{parser::parse_statement, ast::{Statement, Expr}}, storage::row::{ColumnType, ColumnValue}};
+use std::fs;
+
+fn setup_catalog(filename: &str) -> Catalog {
+    let _ = fs::remove_file(filename);
+    Catalog::open(Pager::new(filename).unwrap()).unwrap()
+}
+
+#[test]
+fn parse_default_values() {
+    let stmt = parse_statement("CREATE TABLE t (id INTEGER, name TEXT DEFAULT 'anon', age INTEGER DEFAULT 18 NOT NULL)").unwrap();
+    if let Statement::CreateTable { columns, .. } = stmt {
+        assert_eq!(columns[1].default_value, Some("anon".into()));
+        assert_eq!(columns[2].default_value, Some("18".into()));
+        assert!(columns[2].not_null);
+    } else { panic!("expected create table"); }
+}
+
+#[test]
+fn insert_with_defaults() {
+    let filename = "test_defaults.db";
+    let mut catalog = setup_catalog(filename);
+    handle_statement(&mut catalog, parse_statement("CREATE TABLE t (id INTEGER, name TEXT DEFAULT 'anon', age INTEGER DEFAULT 18)").unwrap()).unwrap();
+    handle_statement(&mut catalog, parse_statement("INSERT INTO t VALUES (1, DEFAULT, 20)").unwrap()).unwrap();
+    handle_statement(&mut catalog, parse_statement("INSERT INTO t VALUES (2)").unwrap()).unwrap();
+    let mut out = Vec::new();
+    execute_select_with_indexes(&mut catalog, "t", Some(Expr::Equals { left: "id".into(), right: "2".into() }), &mut out).unwrap();
+    assert_eq!(out[0].data.0[1], ColumnValue::Text("anon".into()));
+    assert_eq!(out[0].data.0[2], ColumnValue::Integer(18));
+}

--- a/tests/foreign_keys.rs
+++ b/tests/foreign_keys.rs
@@ -11,7 +11,9 @@ fn foreign_key_basic() {
     // create users table
     let create_users = Statement::CreateTable {
         table_name: "users".into(),
-        columns: vec![("id".into(), ColumnType::Integer, false)],
+        columns: vec![
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None }
+        ],
         fks: Vec::new(),
         if_not_exists: false,
     };
@@ -55,7 +57,9 @@ fn foreign_key_on_delete_cascade() {
     // users
     let create_users = Statement::CreateTable {
         table_name: "users".into(),
-        columns: vec![("id".into(), ColumnType::Integer, false)],
+        columns: vec![
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None }
+        ],
         fks: Vec::new(),
         if_not_exists: false,
     };

--- a/tests/having.rs
+++ b/tests/having.rs
@@ -13,9 +13,9 @@ fn having_basic_sum() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "sales".into(),
         columns: vec![
-            ("id".into(), ColumnType::Integer, false),
-            ("region".into(), ColumnType::Text, false),
-            ("amount".into(), ColumnType::Integer, false),
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "region".into(), col_type: ColumnType::Text, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "amount".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
         ],
         fks: Vec::new(),
         if_not_exists: false,
@@ -55,9 +55,9 @@ fn having_with_where() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "employees".into(),
         columns: vec![
-            ("id".into(), ColumnType::Integer, false),
-            ("dept".into(), ColumnType::Text, false),
-            ("active".into(), ColumnType::Integer, false),
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "dept".into(), col_type: ColumnType::Text, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "active".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
         ],
         fks: Vec::new(),
         if_not_exists: false,
@@ -103,7 +103,7 @@ fn having_filters_all() {
     let mut catalog = setup_catalog(filename);
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "t".into(),
-        columns: vec![("id".into(), ColumnType::Integer, false)],
+        columns: vec![aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None }],
         fks: Vec::new(),
         if_not_exists: false,
     }).unwrap();

--- a/tests/multi_join.rs
+++ b/tests/multi_join.rs
@@ -15,8 +15,8 @@ fn join_two_tables() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "a".into(),
         columns: vec![
-            ("id".into(), ColumnType::Integer, false),
-            ("v".into(), ColumnType::Text, false),
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "v".into(), col_type: ColumnType::Text, not_null: false, default_value: None },
         ],
         fks: Vec::new(),
         if_not_exists: false,
@@ -24,9 +24,9 @@ fn join_two_tables() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "b".into(),
         columns: vec![
-            ("id".into(), ColumnType::Integer, false),
-            ("a_id".into(), ColumnType::Integer, false),
-            ("w".into(), ColumnType::Text, false),
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "a_id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "w".into(), col_type: ColumnType::Text, not_null: false, default_value: None },
         ],
         fks: Vec::new(),
         if_not_exists: false,
@@ -62,8 +62,8 @@ fn join_three_tables() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "a".into(),
         columns: vec![
-            ("id".into(), ColumnType::Integer, false),
-            ("v".into(), ColumnType::Text, false),
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "v".into(), col_type: ColumnType::Text, not_null: false, default_value: None },
         ],
         fks: Vec::new(),
         if_not_exists: false,
@@ -71,9 +71,9 @@ fn join_three_tables() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "b".into(),
         columns: vec![
-            ("id".into(), ColumnType::Integer, false),
-            ("a_id".into(), ColumnType::Integer, false),
-            ("w".into(), ColumnType::Text, false),
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "a_id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "w".into(), col_type: ColumnType::Text, not_null: false, default_value: None },
         ],
         fks: Vec::new(),
         if_not_exists: false,
@@ -81,9 +81,9 @@ fn join_three_tables() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "c".into(),
         columns: vec![
-            ("id".into(), ColumnType::Integer, false),
-            ("b_id".into(), ColumnType::Integer, false),
-            ("x".into(), ColumnType::Text, false),
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "b_id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "x".into(), col_type: ColumnType::Text, not_null: false, default_value: None },
         ],
         fks: Vec::new(),
         if_not_exists: false,
@@ -112,8 +112,8 @@ fn join_with_where() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "a".into(),
         columns: vec![
-            ("id".into(), ColumnType::Integer, false),
-            ("v".into(), ColumnType::Text, false),
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "v".into(), col_type: ColumnType::Text, not_null: false, default_value: None },
         ],
         fks: Vec::new(),
         if_not_exists: false,
@@ -121,9 +121,9 @@ fn join_with_where() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "b".into(),
         columns: vec![
-            ("id".into(), ColumnType::Integer, false),
-            ("a_id".into(), ColumnType::Integer, false),
-            ("w".into(), ColumnType::Text, false),
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "a_id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "w".into(), col_type: ColumnType::Text, not_null: false, default_value: None },
         ],
         fks: Vec::new(),
         if_not_exists: false,

--- a/tests/nested_queries.rs
+++ b/tests/nested_queries.rs
@@ -25,7 +25,9 @@ fn execute_from_subquery_simple() {
     let mut catalog = setup_catalog(filename);
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "t1".into(),
-        columns: vec![("id".into(), ColumnType::Integer, false)],
+        columns: vec![
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None }
+        ],
         fks: Vec::new(),
         if_not_exists: false,
     }).unwrap();
@@ -59,13 +61,13 @@ fn execute_where_in_subquery() {
     let mut catalog = setup_catalog(filename);
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "users".into(),
-        columns: vec![("id".into(), ColumnType::Integer, false)],
+        columns: vec![aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None }],
         fks: Vec::new(),
         if_not_exists: false,
     }).unwrap();
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "admins".into(),
-        columns: vec![("id".into(), ColumnType::Integer, false)],
+        columns: vec![aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None }],
         fks: Vec::new(),
         if_not_exists: false,
     }).unwrap();
@@ -106,8 +108,8 @@ fn execute_exists_correlated() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "users".into(),
         columns: vec![
-            ("id".into(), ColumnType::Integer, false),
-            ("name".into(), ColumnType::Text, false),
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "name".into(), col_type: ColumnType::Text, not_null: false, default_value: None },
         ],
         fks: Vec::new(),
         if_not_exists: false,
@@ -115,9 +117,9 @@ fn execute_exists_correlated() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "orders".into(),
         columns: vec![
-            ("id".into(), ColumnType::Integer, false),
-            ("user_id".into(), ColumnType::Integer, false),
-            ("product".into(), ColumnType::Text, false),
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "user_id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "product".into(), col_type: ColumnType::Text, not_null: false, default_value: None },
         ],
         fks: Vec::new(),
         if_not_exists: false,
@@ -147,8 +149,8 @@ fn execute_exists_constant() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "users".into(),
         columns: vec![
-            ("id".into(), ColumnType::Integer, false),
-            ("name".into(), ColumnType::Text, false),
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "name".into(), col_type: ColumnType::Text, not_null: false, default_value: None },
         ],
         fks: Vec::new(),
         if_not_exists: false,
@@ -156,9 +158,9 @@ fn execute_exists_constant() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "orders".into(),
         columns: vec![
-            ("id".into(), ColumnType::Integer, false),
-            ("user_id".into(), ColumnType::Integer, false),
-            ("product".into(), ColumnType::Text, false),
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "user_id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "product".into(), col_type: ColumnType::Text, not_null: false, default_value: None },
         ],
         fks: Vec::new(),
         if_not_exists: false,
@@ -196,8 +198,8 @@ fn execute_scalar_subquery() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "users".into(),
         columns: vec![
-            ("id".into(), ColumnType::Integer, false),
-            ("name".into(), ColumnType::Text, false),
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "name".into(), col_type: ColumnType::Text, not_null: false, default_value: None },
         ],
         fks: Vec::new(),
         if_not_exists: false,
@@ -205,8 +207,8 @@ fn execute_scalar_subquery() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "orders".into(),
         columns: vec![
-            ("id".into(), ColumnType::Integer, false),
-            ("user_id".into(), ColumnType::Integer, false),
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "user_id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
         ],
         fks: Vec::new(),
         if_not_exists: false,

--- a/tests/not_null.rs
+++ b/tests/not_null.rs
@@ -11,10 +11,10 @@ fn parse_create_not_null() {
     let stmt = parse_statement("CREATE TABLE persons (id INTEGER NOT NULL, last_name TEXT NOT NULL, first_name TEXT NOT NULL, age INTEGER)").unwrap();
     if let Statement::CreateTable { columns, .. } = stmt {
         assert_eq!(columns.len(), 4);
-        assert!(columns[0].2);
-        assert!(columns[1].2);
-        assert!(columns[2].2);
-        assert!(!columns[3].2);
+        assert!(columns[0].not_null);
+        assert!(columns[1].not_null);
+        assert!(columns[2].not_null);
+        assert!(!columns[3].not_null);
     } else { panic!("expected create table"); }
 }
 

--- a/tests/nullability.rs
+++ b/tests/nullability.rs
@@ -21,8 +21,8 @@ fn insert_and_retrieve_null() {
     handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "users".into(),
         columns: vec![
-            ("id".into(), ColumnType::Integer, false),
-            ("nickname".into(), ColumnType::Text, false),
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "nickname".into(), col_type: ColumnType::Text, not_null: false, default_value: None },
         ],
         fks: Vec::new(),
         if_not_exists: false,

--- a/tests/numeric_types.rs
+++ b/tests/numeric_types.rs
@@ -10,10 +10,10 @@ fn setup_catalog(filename: &str) -> Catalog {
 fn parse_numeric_types() {
     let stmt = parse_statement("CREATE TABLE nums (a SMALLINT(5) UNSIGNED, b MEDIUMINT(6), c DOUBLE(8,2) UNSIGNED, d DATE)").unwrap();
     if let Statement::CreateTable { columns, .. } = stmt {
-        assert_eq!(columns[0].1, ColumnType::SmallInt { width: 5, unsigned: true });
-        assert_eq!(columns[1].1, ColumnType::MediumInt { width: 6, unsigned: false });
-        assert_eq!(columns[2].1, ColumnType::Double { precision: 8, scale: 2, unsigned: true });
-        assert_eq!(columns[3].1, ColumnType::Date);
+        assert_eq!(columns[0].col_type, ColumnType::SmallInt { width: 5, unsigned: true });
+        assert_eq!(columns[1].col_type, ColumnType::MediumInt { width: 6, unsigned: false });
+        assert_eq!(columns[2].col_type, ColumnType::Double { precision: 8, scale: 2, unsigned: true });
+        assert_eq!(columns[3].col_type, ColumnType::Date);
     } else { panic!("expected create table"); }
 }
 
@@ -23,7 +23,9 @@ fn smallint_range() {
     let mut catalog = setup_catalog(filename);
     handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "t".into(),
-        columns: vec![("id".into(), ColumnType::SmallInt { width: 5, unsigned: true }, false)],
+        columns: vec![
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::SmallInt { width: 5, unsigned: true }, not_null: false, default_value: None }
+        ],
         fks: Vec::new(),
         if_not_exists: false,
     }).unwrap();
@@ -40,7 +42,9 @@ fn mediumint_range() {
     let mut catalog = setup_catalog(filename);
     handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "t".into(),
-        columns: vec![("val".into(), ColumnType::MediumInt { width: 6, unsigned: false }, false)],
+        columns: vec![
+            aerodb::sql::ast::ColumnDef { name: "val".into(), col_type: ColumnType::MediumInt { width: 6, unsigned: false }, not_null: false, default_value: None }
+        ],
         fks: Vec::new(),
         if_not_exists: false,
     }).unwrap();
@@ -58,8 +62,8 @@ fn double_unsigned() {
     handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "t".into(),
         columns: vec![
-            ("id".into(), ColumnType::Integer, false),
-            ("price".into(), ColumnType::Double { precision: 8, scale: 2, unsigned: true }, false)
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "price".into(), col_type: ColumnType::Double { precision: 8, scale: 2, unsigned: true }, not_null: false, default_value: None }
         ],
         fks: Vec::new(),
         if_not_exists: false,
@@ -72,10 +76,10 @@ fn double_unsigned() {
 fn parse_datetime_types() {
     let stmt = parse_statement("CREATE TABLE t (a DATETIME, b TIMESTAMP, c TIME, d YEAR)").unwrap();
     if let Statement::CreateTable { columns, .. } = stmt {
-        assert_eq!(columns[0].1, ColumnType::DateTime);
-        assert_eq!(columns[1].1, ColumnType::Timestamp);
-        assert_eq!(columns[2].1, ColumnType::Time);
-        assert_eq!(columns[3].1, ColumnType::Year);
+        assert_eq!(columns[0].col_type, ColumnType::DateTime);
+        assert_eq!(columns[1].col_type, ColumnType::Timestamp);
+        assert_eq!(columns[2].col_type, ColumnType::Time);
+        assert_eq!(columns[3].col_type, ColumnType::Year);
     } else { panic!("expected create table"); }
 }
 
@@ -86,8 +90,8 @@ fn date_validation() {
     handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "t".into(),
         columns: vec![
-            ("id".into(), ColumnType::Integer, false),
-            ("d".into(), ColumnType::Date, false),
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "d".into(), col_type: ColumnType::Date, not_null: false, default_value: None },
         ],
         fks: Vec::new(),
         if_not_exists: false,
@@ -104,8 +108,8 @@ fn datetime_validation() {
     handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "t".into(),
         columns: vec![
-            ("id".into(), ColumnType::Integer, false),
-            ("ts".into(), ColumnType::DateTime, false),
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "ts".into(), col_type: ColumnType::DateTime, not_null: false, default_value: None },
         ],
         fks: Vec::new(),
         if_not_exists: false,
@@ -122,8 +126,8 @@ fn time_validation() {
     handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "t".into(),
         columns: vec![
-            ("id".into(), ColumnType::Integer, false),
-            ("t".into(), ColumnType::Time, false),
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "t".into(), col_type: ColumnType::Time, not_null: false, default_value: None },
         ],
         fks: Vec::new(),
         if_not_exists: false,
@@ -140,8 +144,8 @@ fn year_validation() {
     handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "t".into(),
         columns: vec![
-            ("id".into(), ColumnType::Integer, false),
-            ("y".into(), ColumnType::Year, false),
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "y".into(), col_type: ColumnType::Year, not_null: false, default_value: None },
         ],
         fks: Vec::new(),
         if_not_exists: false,

--- a/tests/select_projection.rs
+++ b/tests/select_projection.rs
@@ -13,8 +13,8 @@ fn select_single_column() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "users".into(),
         columns: vec![
-            ("id".into(), ColumnType::Integer, false),
-            ("name".into(), ColumnType::Text, false),
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "name".into(), col_type: ColumnType::Text, not_null: false, default_value: None },
         ],
         fks: Vec::new(),
         if_not_exists: false,
@@ -48,8 +48,8 @@ fn select_two_columns() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "users".into(),
         columns: vec![
-            ("id".into(), ColumnType::Integer, false),
-            ("name".into(), ColumnType::Text, false),
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None },
+            aerodb::sql::ast::ColumnDef { name: "name".into(), col_type: ColumnType::Text, not_null: false, default_value: None },
         ],
         fks: Vec::new(),
         if_not_exists: false,


### PR DESCRIPTION
## Summary
- implement `ColumnDef` with `default_value` option
- parse optional `DEFAULT` literals in CREATE TABLE
- store default values in catalog rows
- apply defaults on INSERT when values are missing or `DEFAULT` keyword used
- update tests for new AST and add default value tests