### PR TITLE
Add PRIMARY KEY constraint support

### DIFF
--- a/src/constraints/mod.rs
+++ b/src/constraints/mod.rs
@@ -1,6 +1,7 @@
 pub mod not_null;
 pub mod default;
 pub mod foreign_key;
+pub mod primary_key;
 
 use crate::catalog::{Catalog, TableInfo};
 use crate::storage::row::RowData;

--- a/src/constraints/primary_key.rs
+++ b/src/constraints/primary_key.rs
@@ -1,0 +1,40 @@
+use std::io;
+use crate::catalog::{Catalog, TableInfo};
+use crate::storage::row::{RowData, ColumnValue};
+use crate::storage::btree::BTree;
+use super::Constraint;
+
+pub struct PrimaryKeyConstraint<'a> {
+    pub columns: &'a [String],
+}
+
+impl<'a> Constraint for PrimaryKeyConstraint<'a> {
+    fn validate_insert(&self, catalog: &mut Catalog, table: &TableInfo, row: &mut RowData) -> io::Result<()> {
+        // ensure not null
+        for col in self.columns {
+            if let Some(idx) = table.columns.iter().position(|(c, _)| c == col) {
+                if matches!(row.0[idx], ColumnValue::Null) {
+                    return Err(io::Error::new(io::ErrorKind::Other, "PRIMARY KEY column cannot be NULL"));
+                }
+            }
+        }
+        // check uniqueness
+        let mut btree = BTree::open_root(&mut catalog.pager, table.root_page)?;
+        let mut cursor = btree.scan_all_rows();
+        while let Some(existing) = cursor.next() {
+            let mut equal = true;
+            for col in self.columns {
+                if let Some(idx) = table.columns.iter().position(|(c, _)| c == col) {
+                    if existing.data.0[idx] != row.0[idx] {
+                        equal = false;
+                        break;
+                    }
+                }
+            }
+            if equal {
+                return Err(io::Error::new(io::ErrorKind::Other, "duplicate primary key"));
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/execution/plan.rs
+++ b/src/execution/plan.rs
@@ -7,6 +7,7 @@ pub enum PlanNode {
     CreateTable {
         table_name: String,
         columns: Vec<ColumnDef>,
+        primary_key: Option<Vec<String>>,
         if_not_exists: bool,
     },
     CreateIndex {
@@ -52,8 +53,8 @@ pub struct MultiJoinPlan {
 
 pub fn plan_statement(stmt: Statement) -> PlanNode {
     match stmt {
-        Statement::CreateTable { table_name, columns, if_not_exists, .. } => {
-            PlanNode::CreateTable { table_name, columns, if_not_exists }
+        Statement::CreateTable { table_name, columns, primary_key, if_not_exists, .. } => {
+            PlanNode::CreateTable { table_name, columns, primary_key, if_not_exists }
         }
         Statement::CreateIndex { index_name, table_name, column_name } => {
             PlanNode::CreateIndex { index_name, table_name, column_name }

--- a/src/sql/ast.rs
+++ b/src/sql/ast.rs
@@ -74,6 +74,7 @@ pub struct ColumnDef {
     pub not_null: bool,
     pub default_value: Option<Expr>,
     pub auto_increment: bool,
+    pub primary_key: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -111,6 +112,7 @@ pub enum Statement {
         table_name: String,
         columns: Vec<ColumnDef>,
         fks: Vec<ForeignKey>,
+        primary_key: Option<Vec<String>>,
         if_not_exists: bool,
     },
     CreateIndex {

--- a/tests/aggregate.rs
+++ b/tests/aggregate.rs
@@ -14,10 +14,9 @@ fn basic_count() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "employees".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false }
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false }
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     for i in 1..=3 {
         aerodb::execution::handle_statement(&mut catalog, parse_statement(&format!("INSERT INTO employees VALUES ({})", i)).unwrap()).unwrap();
@@ -42,11 +41,10 @@ fn simple_grouping() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "employees".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false },
-            aerodb::sql::ast::ColumnDef { name: "department".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false },
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false },
+            aerodb::sql::ast::ColumnDef { name: "department".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false, primary_key: false },
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     let data = vec![
         (1, "d1"),

--- a/tests/auto_increment.rs
+++ b/tests/auto_increment.rs
@@ -27,8 +27,8 @@ fn auto_increment_basic_insert() {
     let mut catalog = Catalog::open(Pager::new(filename).unwrap()).unwrap();
 
     let stmt = parse_statement("CREATE TABLE users (id INT NOT NULL AUTO_INCREMENT, name TEXT)").unwrap();
-    if let Statement::CreateTable { table_name, columns, fks, if_not_exists } = stmt {
-        handle_statement(&mut catalog, Statement::CreateTable { table_name, columns, fks, if_not_exists }).unwrap();
+    if let Statement::CreateTable { table_name, columns, fks, primary_key, if_not_exists } = stmt {
+        handle_statement(&mut catalog, Statement::CreateTable { table_name, columns, fks, primary_key, if_not_exists }).unwrap();
     }
 
     handle_statement(&mut catalog, parse_statement("INSERT INTO users (name) VALUES ('Alice')").unwrap()).unwrap();
@@ -48,8 +48,8 @@ fn auto_increment_explicit_values() {
     let mut catalog = Catalog::open(Pager::new(filename).unwrap()).unwrap();
 
     let stmt = parse_statement("CREATE TABLE users (id INT NOT NULL AUTO_INCREMENT, name TEXT)").unwrap();
-    if let Statement::CreateTable { table_name, columns, fks, if_not_exists } = stmt {
-        handle_statement(&mut catalog, Statement::CreateTable { table_name, columns, fks, if_not_exists }).unwrap();
+    if let Statement::CreateTable { table_name, columns, fks, primary_key, if_not_exists } = stmt {
+        handle_statement(&mut catalog, Statement::CreateTable { table_name, columns, fks, primary_key, if_not_exists }).unwrap();
     }
 
     handle_statement(&mut catalog, parse_statement("INSERT INTO users (id, name) VALUES (10, 'Charlie')").unwrap()).unwrap();
@@ -69,8 +69,8 @@ fn auto_increment_persists_after_restart() {
     {
         let mut catalog = Catalog::open(Pager::new(filename).unwrap()).unwrap();
         let stmt = parse_statement("CREATE TABLE users (id INT NOT NULL AUTO_INCREMENT, name TEXT)").unwrap();
-        if let Statement::CreateTable { table_name, columns, fks, if_not_exists } = stmt {
-            handle_statement(&mut catalog, Statement::CreateTable { table_name, columns, fks, if_not_exists }).unwrap();
+        if let Statement::CreateTable { table_name, columns, fks, primary_key, if_not_exists } = stmt {
+            handle_statement(&mut catalog, Statement::CreateTable { table_name, columns, fks, primary_key, if_not_exists }).unwrap();
         }
         handle_statement(&mut catalog, parse_statement("INSERT INTO users (name) VALUES ('Alice')").unwrap()).unwrap();
         handle_statement(&mut catalog, parse_statement("INSERT INTO users (name) VALUES ('Bob')").unwrap()).unwrap();

--- a/tests/char_type.rs
+++ b/tests/char_type.rs
@@ -14,11 +14,10 @@ fn char_column_basic() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "items".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "code".into(), col_type: ColumnType::Char(3), not_null: false, default_value: None, auto_increment: false},
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "code".into(), col_type: ColumnType::Char(3), not_null: false, default_value: None, auto_increment: false, primary_key: false},
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     aerodb::execution::handle_statement(&mut catalog, Statement::Insert { table_name: "items".into(), columns: None, values: vec![Expr::Literal("1".into()), Expr::Literal("A".into())] }).unwrap();
     let stmt = parse_statement("SELECT code FROM items").unwrap();
@@ -42,11 +41,10 @@ fn char_column_validate_length() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "items".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "code".into(), col_type: ColumnType::Char(3), not_null: false, default_value: None, auto_increment: false},
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "code".into(), col_type: ColumnType::Char(3), not_null: false, default_value: None, auto_increment: false, primary_key: false},
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     let res = aerodb::execution::handle_statement(
         &mut catalog,

--- a/tests/constraints_module.rs
+++ b/tests/constraints_module.rs
@@ -21,6 +21,7 @@ fn not_null_constraint_fails_on_null() {
         default_values: vec![None],
         auto_increment: vec![false],
         fks: vec![],
+        primary_key: None,
     };
     let mut row = RowData(vec![ColumnValue::Null]);
     let mut catalog = setup_catalog("nn_fail.db");
@@ -48,12 +49,14 @@ fn foreign_key_constraint_detects_missing_parent() {
         default_values: vec![None],
         auto_increment: vec![false],
         fks: vec![],
+        primary_key: None,
     };
     catalog
         .create_table_with_fks(
             &parent.name,
             vec![("id".into(), ColumnType::Integer, false, None, false)],
             vec![],
+            None,
         )
         .unwrap();
     // child table info
@@ -65,12 +68,14 @@ fn foreign_key_constraint_detects_missing_parent() {
         default_values: vec![None],
         auto_increment: vec![false],
         fks: vec![ForeignKey { columns: vec!["pid".into()], parent_table: "p".into(), parent_columns: vec!["id".into()], on_delete: None, on_update: None }],
+        primary_key: None,
     };
     catalog
         .create_table_with_fks(
             &child.name,
             vec![("pid".into(), ColumnType::Integer, false, None, false)],
             child.fks.clone(),
+            None,
         )
         .unwrap();
     let mut row = RowData(vec![ColumnValue::Integer(1)]);

--- a/tests/foreign_keys.rs
+++ b/tests/foreign_keys.rs
@@ -13,10 +13,9 @@ fn foreign_key_basic() {
     let create_users = Statement::CreateTable {
         table_name: "users".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false}
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false}
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     };
     aerodb::execution::handle_statement(&mut catalog, create_users).unwrap();
 
@@ -25,9 +24,9 @@ fn foreign_key_basic() {
         "CREATE TABLE orders (id INTEGER, user_id INTEGER, FOREIGN KEY (user_id) REFERENCES users (id))",
     )
     .unwrap();
-    if let Statement::CreateTable { table_name, columns, fks, if_not_exists } = stmt {
+    if let Statement::CreateTable { table_name, columns, fks, primary_key, if_not_exists } = stmt {
         assert_eq!(fks.len(), 1);
-        aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable { table_name, columns, fks, if_not_exists }).unwrap();
+        aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable { table_name, columns, fks, primary_key, if_not_exists }).unwrap();
     } else { panic!("expected create table") }
 
     // insert a user id=1
@@ -60,10 +59,9 @@ fn foreign_key_on_delete_cascade() {
     let create_users = Statement::CreateTable {
         table_name: "users".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false}
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false}
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     };
     aerodb::execution::handle_statement(&mut catalog, create_users).unwrap();
 
@@ -71,8 +69,8 @@ fn foreign_key_on_delete_cascade() {
     let stmt = parse_statement(
         "CREATE TABLE orders (id INTEGER, user_id INTEGER, FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE)"
     ).unwrap();
-    if let Statement::CreateTable { table_name, columns, fks, if_not_exists } = stmt {
-        aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable { table_name, columns, fks, if_not_exists }).unwrap();
+    if let Statement::CreateTable { table_name, columns, fks, primary_key, if_not_exists } = stmt {
+        aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable { table_name, columns, fks, primary_key, if_not_exists }).unwrap();
     } else { panic!("expected create") }
 
     let insert_user = parse_statement("INSERT INTO users VALUES (1)").unwrap();

--- a/tests/having.rs
+++ b/tests/having.rs
@@ -14,12 +14,11 @@ fn having_basic_sum() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "sales".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "region".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "amount".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "region".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "amount".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     let rows = vec![
         (1, "north", 50),
@@ -53,12 +52,11 @@ fn having_with_where() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "employees".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "dept".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "active".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "dept".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "active".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     let rows = vec![
         (1, "a", 1),
@@ -98,9 +96,8 @@ fn having_filters_all() {
     let mut catalog = setup_catalog(filename);
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "t".into(),
-        columns: vec![aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false}],
-        fks: Vec::new(),
-        if_not_exists: false,
+        columns: vec![aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false}],
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     for i in 1..=3 {
         aerodb::execution::handle_statement(&mut catalog, parse_statement(&format!("INSERT INTO t VALUES ({})", i)).unwrap()).unwrap();

--- a/tests/multi_join.rs
+++ b/tests/multi_join.rs
@@ -16,21 +16,19 @@ fn join_two_tables() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "a".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "v".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false},
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "v".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false, primary_key: false},
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "b".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "a_id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "w".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false},
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "a_id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "w".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false, primary_key: false},
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     // insert rows
     for (id, v) in &[(1,"av1"),(2,"av2")] {
@@ -63,31 +61,28 @@ fn join_three_tables() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "a".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "v".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false},
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "v".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false, primary_key: false},
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "b".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "a_id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "w".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false},
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "a_id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "w".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false, primary_key: false},
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "c".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "b_id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "x".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false},
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "b_id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "x".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false, primary_key: false},
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     aerodb::execution::handle_statement(&mut catalog, parse_statement("INSERT INTO a VALUES (1, 'av1')").unwrap()).unwrap();
     aerodb::execution::handle_statement(&mut catalog, parse_statement("INSERT INTO a VALUES (2, 'av2')").unwrap()).unwrap();
@@ -113,21 +108,19 @@ fn join_with_where() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "a".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "v".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false},
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "v".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false, primary_key: false},
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "b".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "a_id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "w".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false},
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "a_id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "w".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false, primary_key: false},
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     aerodb::execution::handle_statement(&mut catalog, parse_statement("INSERT INTO a VALUES (1, 'av1')").unwrap()).unwrap();
     aerodb::execution::handle_statement(&mut catalog, parse_statement("INSERT INTO a VALUES (2, 'av2')").unwrap()).unwrap();

--- a/tests/nested_queries.rs
+++ b/tests/nested_queries.rs
@@ -27,10 +27,9 @@ fn execute_from_subquery_simple() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "t1".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false}
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false}
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     aerodb::execution::handle_statement(&mut catalog, parse_statement("INSERT INTO t1 VALUES (1)").unwrap()).unwrap();
     aerodb::execution::handle_statement(&mut catalog, parse_statement("INSERT INTO t1 VALUES (2)").unwrap()).unwrap();
@@ -62,15 +61,13 @@ fn execute_where_in_subquery() {
     let mut catalog = setup_catalog(filename);
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "users".into(),
-        columns: vec![aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false}],
-        fks: Vec::new(),
-        if_not_exists: false,
+        columns: vec![aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false}],
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "admins".into(),
-        columns: vec![aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false}],
-        fks: Vec::new(),
-        if_not_exists: false,
+        columns: vec![aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false}],
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     for id in 1..=3 {
         aerodb::execution::handle_statement(&mut catalog, parse_statement(&format!("INSERT INTO users VALUES ({})", id)).unwrap()).unwrap();
@@ -109,21 +106,19 @@ fn execute_exists_correlated() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "users".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "name".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false},
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "name".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false, primary_key: false},
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "orders".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "user_id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "product".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false},
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "user_id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "product".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false, primary_key: false},
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     aerodb::execution::handle_statement(&mut catalog, parse_statement("INSERT INTO users VALUES (1, 'Alice')").unwrap()).unwrap();
     aerodb::execution::handle_statement(&mut catalog, parse_statement("INSERT INTO users VALUES (2, 'Bob')").unwrap()).unwrap();
@@ -150,21 +145,19 @@ fn execute_exists_constant() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "users".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "name".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false},
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "name".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false, primary_key: false},
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "orders".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "user_id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "product".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false},
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "user_id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "product".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false, primary_key: false},
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     aerodb::execution::handle_statement(&mut catalog, parse_statement("INSERT INTO users VALUES (1, 'Alice')").unwrap()).unwrap();
     aerodb::execution::handle_statement(&mut catalog, parse_statement("INSERT INTO users VALUES (2, 'Bob')").unwrap()).unwrap();
@@ -199,20 +192,18 @@ fn execute_scalar_subquery() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "users".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "name".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false},
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "name".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false, primary_key: false},
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "orders".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "user_id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "user_id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     aerodb::execution::handle_statement(&mut catalog, parse_statement("INSERT INTO users VALUES (1, 'Alice')").unwrap()).unwrap();
     aerodb::execution::handle_statement(&mut catalog, parse_statement("INSERT INTO users VALUES (2, 'Bob')").unwrap()).unwrap();

--- a/tests/not_null.rs
+++ b/tests/not_null.rs
@@ -24,8 +24,8 @@ fn enforce_not_null() {
     let filename = "test_not_null.db";
     let mut catalog = setup_catalog(filename);
     let stmt = parse_statement("CREATE TABLE persons (id INTEGER NOT NULL, last_name TEXT NOT NULL, first_name TEXT NOT NULL, age INTEGER)").unwrap();
-    if let Statement::CreateTable { table_name, columns, fks, if_not_exists } = stmt {
-        handle_statement(&mut catalog, Statement::CreateTable { table_name, columns, fks, if_not_exists }).unwrap();
+    if let Statement::CreateTable { table_name, columns, fks, primary_key, if_not_exists } = stmt {
+        handle_statement(&mut catalog, Statement::CreateTable { table_name, columns, fks, primary_key, if_not_exists }).unwrap();
     } else { panic!("expected create table"); }
 
     // valid insert with NULL age

--- a/tests/nullability.rs
+++ b/tests/nullability.rs
@@ -22,11 +22,10 @@ fn insert_and_retrieve_null() {
     handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "users".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "nickname".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false},
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "nickname".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false, primary_key: false},
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     handle_statement(&mut catalog, parse_statement("INSERT INTO users VALUES (1, NULL)").unwrap()).unwrap();
     let mut out = Vec::new();

--- a/tests/numeric_types.rs
+++ b/tests/numeric_types.rs
@@ -25,10 +25,9 @@ fn smallint_range() {
     handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "t".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::SmallInt { width: 5, unsigned: true }, not_null: false, default_value: None, auto_increment: false}
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::SmallInt { width: 5, unsigned: true }, not_null: false, default_value: None, auto_increment: false, primary_key: false}
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     let res = handle_statement(&mut catalog, parse_statement("INSERT INTO t VALUES (-1)").unwrap());
     assert!(res.is_err());
@@ -44,10 +43,9 @@ fn mediumint_range() {
     handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "t".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "val".into(), col_type: ColumnType::MediumInt { width: 6, unsigned: false }, not_null: false, default_value: None, auto_increment: false}
+            aerodb::sql::ast::ColumnDef { name: "val".into(), col_type: ColumnType::MediumInt { width: 6, unsigned: false }, not_null: false, default_value: None, auto_increment: false, primary_key: false}
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     let res = handle_statement(&mut catalog, parse_statement("INSERT INTO t VALUES (-9000000)").unwrap());
     assert!(res.is_err());
@@ -63,11 +61,10 @@ fn double_unsigned() {
     handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "t".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "price".into(), col_type: ColumnType::Double { precision: 8, scale: 2, unsigned: true }, not_null: false, default_value: None, auto_increment: false}
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "price".into(), col_type: ColumnType::Double { precision: 8, scale: 2, unsigned: true }, not_null: false, default_value: None, auto_increment: false, primary_key: false}
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     let res = handle_statement(&mut catalog, parse_statement("INSERT INTO t VALUES (1, -1)").unwrap());
     assert!(res.is_err());
@@ -91,11 +88,10 @@ fn date_validation() {
     handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "t".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "d".into(), col_type: ColumnType::Date, not_null: false, default_value: None, auto_increment: false},
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "d".into(), col_type: ColumnType::Date, not_null: false, default_value: None, auto_increment: false, primary_key: false},
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     let res = handle_statement(&mut catalog, parse_statement("INSERT INTO t VALUES (1, '2025-13-01')").unwrap());
     assert!(res.is_err());
@@ -109,11 +105,10 @@ fn datetime_validation() {
     handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "t".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "ts".into(), col_type: ColumnType::DateTime, not_null: false, default_value: None, auto_increment: false},
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "ts".into(), col_type: ColumnType::DateTime, not_null: false, default_value: None, auto_increment: false, primary_key: false},
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     let res = handle_statement(&mut catalog, parse_statement("INSERT INTO t VALUES (1, '2025-02-30 10:00:00')").unwrap());
     assert!(res.is_err());
@@ -127,11 +122,10 @@ fn time_validation() {
     handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "t".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "t".into(), col_type: ColumnType::Time, not_null: false, default_value: None, auto_increment: false},
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "t".into(), col_type: ColumnType::Time, not_null: false, default_value: None, auto_increment: false, primary_key: false},
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     let res = handle_statement(&mut catalog, parse_statement("INSERT INTO t VALUES (1, '839:00:00')").unwrap());
     assert!(res.is_err());
@@ -145,11 +139,10 @@ fn year_validation() {
     handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "t".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "y".into(), col_type: ColumnType::Year, not_null: false, default_value: None, auto_increment: false},
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "y".into(), col_type: ColumnType::Year, not_null: false, default_value: None, auto_increment: false, primary_key: false},
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     let res = handle_statement(&mut catalog, parse_statement("INSERT INTO t VALUES (1, '1900')").unwrap());
     assert!(res.is_err());

--- a/tests/primary_key.rs
+++ b/tests/primary_key.rs
@@ -1,0 +1,85 @@
+use aerodb::{catalog::Catalog, storage::pager::Pager, sql::parser::parse_statement, execution::{handle_statement, execute_select_with_indexes, row_to_strings}};
+use aerodb::sql::ast::Statement;
+use std::fs;
+
+fn setup_catalog(filename: &str) -> Catalog {
+    let _ = fs::remove_file(filename);
+    let _ = fs::remove_file(format!("{}.wal", filename));
+    Catalog::open(Pager::new(filename).unwrap()).unwrap()
+}
+
+#[test]
+fn primary_key_happy_path() {
+    let filename = "pk_basic.db";
+    let mut catalog = setup_catalog(filename);
+    let create = parse_statement("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)").unwrap();
+    if let Statement::CreateTable { table_name, columns, fks, primary_key, if_not_exists } = create {
+        handle_statement(&mut catalog, Statement::CreateTable { table_name, columns, fks, primary_key, if_not_exists }).unwrap();
+    }
+    handle_statement(&mut catalog, parse_statement("INSERT INTO users VALUES (1,'Alice')").unwrap()).unwrap();
+    let mut rows = Vec::new();
+    execute_select_with_indexes(&mut catalog, "users", None, &mut rows).unwrap();
+    let vals: Vec<Vec<String>> = rows.iter().map(|r| row_to_strings(r)).collect();
+    assert_eq!(vals, vec![vec![String::from("1"), String::from("Alice")]]);
+}
+
+#[test]
+fn primary_key_duplicate_error() {
+    let filename = "pk_dup.db";
+    let mut catalog = setup_catalog(filename);
+    let create = parse_statement("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)").unwrap();
+    if let Statement::CreateTable { table_name, columns, fks, primary_key, if_not_exists } = create {
+        handle_statement(&mut catalog, Statement::CreateTable { table_name, columns, fks, primary_key, if_not_exists }).unwrap();
+    }
+    handle_statement(&mut catalog, parse_statement("INSERT INTO users VALUES (1,'Alice')").unwrap()).unwrap();
+    let res = handle_statement(&mut catalog, parse_statement("INSERT INTO users VALUES (1,'Bob')").unwrap());
+    assert!(res.is_err());
+}
+
+#[test]
+fn primary_key_null_error() {
+    let filename = "pk_null.db";
+    let mut catalog = setup_catalog(filename);
+    let create = parse_statement("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)").unwrap();
+    if let Statement::CreateTable { table_name, columns, fks, primary_key, if_not_exists } = create {
+        handle_statement(&mut catalog, Statement::CreateTable { table_name, columns, fks, primary_key, if_not_exists }).unwrap();
+    }
+    let res = handle_statement(&mut catalog, parse_statement("INSERT INTO users VALUES (NULL,'Charlie')").unwrap());
+    assert!(res.is_err());
+}
+
+#[test]
+fn primary_key_composite() {
+    let filename = "pk_comp.db";
+    let mut catalog = setup_catalog(filename);
+    let create = parse_statement("CREATE TABLE orders (order_id INT, item_id INT, PRIMARY KEY(order_id, item_id))").unwrap();
+    if let Statement::CreateTable { table_name, columns, fks, primary_key, if_not_exists } = create {
+        handle_statement(&mut catalog, Statement::CreateTable { table_name, columns, fks, primary_key, if_not_exists }).unwrap();
+    }
+    handle_statement(&mut catalog, parse_statement("INSERT INTO orders VALUES (1,1)").unwrap()).unwrap();
+    let dup = handle_statement(&mut catalog, parse_statement("INSERT INTO orders VALUES (1,1)").unwrap());
+    assert!(dup.is_err());
+    let null_err = handle_statement(&mut catalog, parse_statement("INSERT INTO orders VALUES (1,NULL)").unwrap());
+    assert!(null_err.is_err());
+}
+
+#[test]
+fn primary_key_persistence() {
+    let filename = "pk_persist.db";
+    let _ = fs::remove_file(filename);
+    let _ = fs::remove_file(format!("{}.wal", filename));
+    {
+        let mut catalog = Catalog::open(Pager::new(filename).unwrap()).unwrap();
+        let create = parse_statement("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)").unwrap();
+        if let Statement::CreateTable { table_name, columns, fks, primary_key, if_not_exists } = create {
+            handle_statement(&mut catalog, Statement::CreateTable { table_name, columns, fks, primary_key, if_not_exists }).unwrap();
+        }
+        handle_statement(&mut catalog, parse_statement("INSERT INTO users VALUES (1,'Alice')").unwrap()).unwrap();
+    }
+    {
+        let mut catalog = Catalog::open(Pager::new(filename).unwrap()).unwrap();
+        let res = handle_statement(&mut catalog, parse_statement("INSERT INTO users VALUES (1,'Bob')").unwrap());
+        assert!(res.is_err());
+    }
+}
+

--- a/tests/select_projection.rs
+++ b/tests/select_projection.rs
@@ -14,11 +14,10 @@ fn select_single_column() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "users".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "name".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false},
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "name".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false, primary_key: false},
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     aerodb::execution::handle_statement(&mut catalog, parse_statement("INSERT INTO users VALUES (1, 'bob')").unwrap()).unwrap();
     let stmt = parse_statement("SELECT name FROM users").unwrap();
@@ -49,11 +48,10 @@ fn select_two_columns() {
     aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
         table_name: "users".into(),
         columns: vec![
-            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false},
-            aerodb::sql::ast::ColumnDef { name: "name".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false},
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "name".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false, primary_key: false},
         ],
-        fks: Vec::new(),
-        if_not_exists: false,
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     aerodb::execution::handle_statement(&mut catalog, parse_statement("INSERT INTO users VALUES (1, 'bob')").unwrap()).unwrap();
     let stmt = parse_statement("SELECT id, name FROM users").unwrap();


### PR DESCRIPTION
## Summary
- implement PRIMARY KEY constraint enforcement
- extend parser and catalog to persist primary key info
- validate uniqueness and non-null via new constraint
- update tests and schemas to use primary_key field
- add comprehensive tests for primary key behavior
