### PR TITLE
Introduce DbError enum for detailed error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ lazy_static = "1.5.0"
 log = "0.4.27"
 nom = "8.0.0"
 chrono = { version = "0.4", default-features = false, features = ["alloc", "clock", "serde"] }
+thiserror = "1.0"

--- a/src/constraints/default.rs
+++ b/src/constraints/default.rs
@@ -1,12 +1,12 @@
-use std::io;
 use crate::sql::ast::Expr;
 use crate::storage::row::ColumnValue;
 use crate::sql::functions::FunctionEvaluator;
+use crate::error::{DbError, DbResult};
 
 pub struct DefaultConstraint;
 
 impl DefaultConstraint {
-    pub fn evaluate(expr: &Expr) -> io::Result<String> {
+    pub fn evaluate(expr: &Expr) -> DbResult<String> {
         match expr {
             Expr::Literal(s) => Ok(s.clone()),
             Expr::FunctionCall { name, args } => {
@@ -19,10 +19,10 @@ impl DefaultConstraint {
                     .collect::<Result<_, _>>()?;
                 match FunctionEvaluator::evaluate_function(name, &arg_vals) {
                     Ok(val) => Ok(val.to_string_value()),
-                    Err(_) => Err(io::Error::new(io::ErrorKind::Other, "function error")),
+                    Err(_) => Err(DbError::InvalidValue("function error".into())),
                 }
             }
-            _ => Err(io::Error::new(io::ErrorKind::Other, "unsupported default expression")),
+            _ => Err(DbError::InvalidValue("unsupported default expression".into())),
         }
     }
 }
@@ -32,7 +32,7 @@ use crate::storage::row::RowData;
 use super::Constraint;
 
 impl Constraint for DefaultConstraint {
-    fn validate_insert(&self, _catalog: &mut Catalog, _table: &TableInfo, _row: &mut RowData) -> io::Result<()> {
+    fn validate_insert(&self, _catalog: &mut Catalog, _table: &TableInfo, _row: &mut RowData) -> DbResult<()> {
         Ok(())
     }
 }

--- a/src/constraints/mod.rs
+++ b/src/constraints/mod.rs
@@ -5,11 +5,11 @@ pub mod primary_key;
 
 use crate::catalog::{Catalog, TableInfo};
 use crate::storage::row::RowData;
-use std::io;
+use crate::error::DbResult;
 
 pub trait Constraint {
-    fn validate_insert(&self, catalog: &mut Catalog, table: &TableInfo, row: &mut RowData) -> io::Result<()>;
-    fn validate_delete(&self, _catalog: &mut Catalog, _table: &TableInfo, _row: &RowData) -> io::Result<()> {
+    fn validate_insert(&self, catalog: &mut Catalog, table: &TableInfo, row: &mut RowData) -> DbResult<()>;
+    fn validate_delete(&self, _catalog: &mut Catalog, _table: &TableInfo, _row: &RowData) -> DbResult<()> {
         Ok(())
     }
 }

--- a/src/constraints/not_null.rs
+++ b/src/constraints/not_null.rs
@@ -1,22 +1,16 @@
-use std::io;
 use crate::catalog::TableInfo;
 use crate::storage::row::{RowData, ColumnValue};
 use crate::catalog::Catalog;
+use crate::error::{DbError, DbResult};
 use super::Constraint;
 
 pub struct NotNullConstraint;
 
 impl Constraint for NotNullConstraint {
-    fn validate_insert(&self, _catalog: &mut Catalog, table: &TableInfo, row: &mut RowData) -> io::Result<()> {
+    fn validate_insert(&self, _catalog: &mut Catalog, table: &TableInfo, row: &mut RowData) -> DbResult<()> {
         for ((val, nn), (name, _)) in row.0.iter().zip(table.not_null.iter()).zip(table.columns.iter()) {
             if *nn && matches!(val, ColumnValue::Null) {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    format!(
-                        "null value in column \"{}\" of relation \"{}\" violates not-null constraint",
-                        name, table.name
-                    ),
-                ));
+                return Err(DbError::NullViolation(name.clone()));
             }
         }
         Ok(())

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,26 @@
+use thiserror::Error;
+use std::io;
+
+#[derive(Debug, Error)]
+pub enum DbError {
+    #[error("table '{0}' not found")]
+    TableNotFound(String),
+    #[error("column '{0}' not found")]
+    ColumnNotFound(String),
+    #[error("duplicate primary key {0}")]
+    DuplicateKey(i32),
+    #[error("null value in column '{0}' violates not-null constraint")]
+    NullViolation(String),
+    #[error("value out of range")]
+    Overflow,
+    #[error("parse error: {0}")]
+    ParseError(String),
+    #[error("invalid value: {0}")]
+    InvalidValue(String),
+    #[error("foreign key violation: {0}")]
+    ForeignKeyViolation(String),
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}
+
+pub type DbResult<T> = Result<T, DbError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,4 @@ pub mod catalog;
 pub mod execution;
 pub mod transaction;
 pub mod constraints;
+pub mod error;

--- a/tests/char_type.rs
+++ b/tests/char_type.rs
@@ -54,5 +54,5 @@ fn char_column_validate_length() {
             values: vec![Expr::Literal("2".into()), Expr::Literal("SASASDADSA".into())],
         },
     );
-    assert!(res.is_err());
+    assert!(matches!(res, Err(aerodb::error::DbError::InvalidValue(_))));
 }

--- a/tests/not_null.rs
+++ b/tests/not_null.rs
@@ -32,10 +32,10 @@ fn enforce_not_null() {
     handle_statement(&mut catalog, parse_statement("INSERT INTO persons VALUES (1, 'siyo', 'siyo', NULL)").unwrap()).unwrap();
     // invalid insert with NULL last_name
     let res = handle_statement(&mut catalog, parse_statement("INSERT INTO persons VALUES (2, NULL, 'siyo', 12)").unwrap());
-    assert!(res.is_err());
+    assert!(matches!(res, Err(aerodb::error::DbError::NullViolation(_))));
     // invalid insert with NULL first_name
     let res = handle_statement(&mut catalog, parse_statement("INSERT INTO persons VALUES (3, 'siyo', NULL, 12)").unwrap());
-    assert!(res.is_err());
+    assert!(matches!(res, Err(aerodb::error::DbError::NullViolation(_))));
 
     // verify stored row
     let mut out = Vec::new();

--- a/tests/numeric_types.rs
+++ b/tests/numeric_types.rs
@@ -30,9 +30,9 @@ fn smallint_range() {
         fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     let res = handle_statement(&mut catalog, parse_statement("INSERT INTO t VALUES (-1)").unwrap());
-    assert!(res.is_err());
+    assert!(matches!(res, Err(aerodb::error::DbError::InvalidValue(_))));
     let res = handle_statement(&mut catalog, parse_statement("INSERT INTO t VALUES (70000)").unwrap());
-    assert!(res.is_err());
+    assert!(matches!(res, Err(aerodb::error::DbError::InvalidValue(_))));
     handle_statement(&mut catalog, parse_statement("INSERT INTO t VALUES (123)").unwrap()).unwrap();
 }
 
@@ -48,9 +48,9 @@ fn mediumint_range() {
         fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     let res = handle_statement(&mut catalog, parse_statement("INSERT INTO t VALUES (-9000000)").unwrap());
-    assert!(res.is_err());
+    assert!(matches!(res, Err(aerodb::error::DbError::InvalidValue(_))));
     let res = handle_statement(&mut catalog, parse_statement("INSERT INTO t VALUES (9000000)").unwrap());
-    assert!(res.is_err());
+    assert!(matches!(res, Err(aerodb::error::DbError::InvalidValue(_))));
     handle_statement(&mut catalog, parse_statement("INSERT INTO t VALUES (100)").unwrap()).unwrap();
 }
 
@@ -67,7 +67,7 @@ fn double_unsigned() {
         fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     let res = handle_statement(&mut catalog, parse_statement("INSERT INTO t VALUES (1, -1)").unwrap());
-    assert!(res.is_err());
+    assert!(matches!(res, Err(aerodb::error::DbError::InvalidValue(_))));
     handle_statement(&mut catalog, parse_statement("INSERT INTO t VALUES (2, 12.34)").unwrap()).unwrap();
 }
 #[test]
@@ -94,7 +94,7 @@ fn date_validation() {
         fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     let res = handle_statement(&mut catalog, parse_statement("INSERT INTO t VALUES (1, '2025-13-01')").unwrap());
-    assert!(res.is_err());
+    assert!(matches!(res, Err(aerodb::error::DbError::InvalidValue(_))));
     handle_statement(&mut catalog, parse_statement("INSERT INTO t VALUES (2, '2025-12-01')").unwrap()).unwrap();
 }
 
@@ -111,7 +111,7 @@ fn datetime_validation() {
         fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     let res = handle_statement(&mut catalog, parse_statement("INSERT INTO t VALUES (1, '2025-02-30 10:00:00')").unwrap());
-    assert!(res.is_err());
+    assert!(matches!(res, Err(aerodb::error::DbError::InvalidValue(_))));
     handle_statement(&mut catalog, parse_statement("INSERT INTO t VALUES (2, '2025-06-08 12:34:56')").unwrap()).unwrap();
 }
 
@@ -128,7 +128,7 @@ fn time_validation() {
         fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     let res = handle_statement(&mut catalog, parse_statement("INSERT INTO t VALUES (1, '839:00:00')").unwrap());
-    assert!(res.is_err());
+    assert!(matches!(res, Err(aerodb::error::DbError::InvalidValue(_))));
     handle_statement(&mut catalog, parse_statement("INSERT INTO t VALUES (2, '12:30:45')").unwrap()).unwrap();
 }
 
@@ -145,6 +145,6 @@ fn year_validation() {
         fks: Vec::new(), primary_key: None, if_not_exists: false,
     }).unwrap();
     let res = handle_statement(&mut catalog, parse_statement("INSERT INTO t VALUES (1, '1900')").unwrap());
-    assert!(res.is_err());
+    assert!(matches!(res, Err(aerodb::error::DbError::InvalidValue(_))));
     handle_statement(&mut catalog, parse_statement("INSERT INTO t VALUES (2, '2020')").unwrap()).unwrap();
 }

--- a/tests/primary_key.rs
+++ b/tests/primary_key.rs
@@ -33,7 +33,7 @@ fn primary_key_duplicate_error() {
     }
     handle_statement(&mut catalog, parse_statement("INSERT INTO users VALUES (1,'Alice')").unwrap()).unwrap();
     let res = handle_statement(&mut catalog, parse_statement("INSERT INTO users VALUES (1,'Bob')").unwrap());
-    assert!(res.is_err());
+    assert!(matches!(res, Err(aerodb::error::DbError::DuplicateKey(1))));
 }
 
 #[test]
@@ -45,7 +45,7 @@ fn primary_key_null_error() {
         handle_statement(&mut catalog, Statement::CreateTable { table_name, columns, fks, primary_key, if_not_exists }).unwrap();
     }
     let res = handle_statement(&mut catalog, parse_statement("INSERT INTO users VALUES (NULL,'Charlie')").unwrap());
-    assert!(res.is_err());
+    assert!(matches!(res, Err(aerodb::error::DbError::NullViolation(_))));
 }
 
 #[test]
@@ -58,9 +58,9 @@ fn primary_key_composite() {
     }
     handle_statement(&mut catalog, parse_statement("INSERT INTO orders VALUES (1,1)").unwrap()).unwrap();
     let dup = handle_statement(&mut catalog, parse_statement("INSERT INTO orders VALUES (1,1)").unwrap());
-    assert!(dup.is_err());
+    assert!(matches!(dup, Err(aerodb::error::DbError::DuplicateKey(1))));
     let null_err = handle_statement(&mut catalog, parse_statement("INSERT INTO orders VALUES (1,NULL)").unwrap());
-    assert!(null_err.is_err());
+    assert!(matches!(null_err, Err(aerodb::error::DbError::NullViolation(_))));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `DbError` enum with variants for common database errors
- switch constraints and runtime logic to return `DbResult`
- print user-friendly messages for each error variant in main
- update several tests to assert specific `DbError` variants
- add `thiserror` dependency

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6848bf4645e88333ab683cf22db858a6