### PR TITLE
Add more SQL operator support

### DIFF
--- a/src/execution/runtime.rs
+++ b/src/execution/runtime.rs
@@ -21,7 +21,7 @@ pub fn execute_delete(catalog: &mut Catalog, table_name: &str, selection: Option
                         let v = val.to_string_value();
                         values.insert(col.clone(), v);
                     }
-                    if crate::sql::ast::evaluate_expression(expr, &values) {
+                    if matches!(crate::sql::ast::evaluate_expression(expr, &values), ColumnValue::Boolean(true)) {
                         collected.push(row);
                     }
                 } else {
@@ -181,7 +181,7 @@ pub fn execute_update(
                         let v = val.to_string_value();
                         values.insert(col.clone(), v);
                     }
-                    if crate::sql::ast::evaluate_expression(expr, &values) {
+                    if matches!(crate::sql::ast::evaluate_expression(expr, &values), ColumnValue::Boolean(true)) {
                         collected.push(row);
                     }
                 } else {
@@ -294,7 +294,7 @@ pub fn execute_select_with_indexes(
                 let v = val.to_string_value();
                 values.insert(col.clone(), v);
             }
-            if crate::sql::ast::evaluate_expression(expr, &values) {
+            if matches!(crate::sql::ast::evaluate_expression(expr, &values), ColumnValue::Boolean(true)) {
                 out.push(row);
             }
         } else {
@@ -371,7 +371,7 @@ pub fn execute_multi_join(
             str_map.insert(k.clone(), s);
         }
         if let Some(ref pred) = plan.where_predicate {
-            if !evaluate_expression(pred, &str_map) {
+            if !matches!(evaluate_expression(pred, &str_map), ColumnValue::Boolean(true)) {
                 continue;
             }
         }
@@ -549,7 +549,7 @@ pub fn execute_group_query(
             }
         }
         if let Some(ref pred) = having {
-            if !crate::sql::ast::evaluate_expression(pred, &value_map) {
+            if !matches!(crate::sql::ast::evaluate_expression(pred, &value_map), ColumnValue::Boolean(true)) {
                 continue;
             }
         }
@@ -949,6 +949,52 @@ fn evaluate_with_catalog(
         Expr::NotEquals { left, right } => {
             Ok(values.get(left).map(String::as_str).unwrap_or(left)
                 != values.get(right).map(String::as_str).unwrap_or(right))
+        }
+        Expr::Add { left, right } => {
+            let l = values.get(left).map(String::as_str).unwrap_or(left).parse::<i64>().unwrap_or(0);
+            let r = values.get(right).map(String::as_str).unwrap_or(right).parse::<i64>().unwrap_or(0);
+            Ok(l + r != 0)
+        }
+        Expr::Subtract { left, right } => {
+            let l = values.get(left).map(String::as_str).unwrap_or(left).parse::<i64>().unwrap_or(0);
+            let r = values.get(right).map(String::as_str).unwrap_or(right).parse::<i64>().unwrap_or(0);
+            Ok(l - r != 0)
+        }
+        Expr::Multiply { left, right } => {
+            let l = values.get(left).map(String::as_str).unwrap_or(left).parse::<i64>().unwrap_or(0);
+            let r = values.get(right).map(String::as_str).unwrap_or(right).parse::<i64>().unwrap_or(0);
+            Ok(l * r != 0)
+        }
+        Expr::Divide { left, right } => {
+            let l = values.get(left).map(String::as_str).unwrap_or(left).parse::<i64>().unwrap_or(0);
+            let r = values.get(right).map(String::as_str).unwrap_or(right).parse::<i64>().unwrap_or(1);
+            if r == 0 { Ok(false) } else { Ok(l / r != 0) }
+        }
+        Expr::Modulo { left, right } => {
+            let l = values.get(left).map(String::as_str).unwrap_or(left).parse::<i64>().unwrap_or(0);
+            let r = values.get(right).map(String::as_str).unwrap_or(right).parse::<i64>().unwrap_or(1);
+            if r == 0 { Ok(false) } else { Ok(l % r != 0) }
+        }
+        Expr::BitwiseAnd { left, right } => {
+            let l = values.get(left).map(String::as_str).unwrap_or(left).parse::<i64>().unwrap_or(0);
+            let r = values.get(right).map(String::as_str).unwrap_or(right).parse::<i64>().unwrap_or(0);
+            Ok((l & r) != 0)
+        }
+        Expr::BitwiseOr { left, right } => {
+            let l = values.get(left).map(String::as_str).unwrap_or(left).parse::<i64>().unwrap_or(0);
+            let r = values.get(right).map(String::as_str).unwrap_or(right).parse::<i64>().unwrap_or(0);
+            Ok((l | r) != 0)
+        }
+        Expr::BitwiseXor { left, right } => {
+            let l = values.get(left).map(String::as_str).unwrap_or(left).parse::<i64>().unwrap_or(0);
+            let r = values.get(right).map(String::as_str).unwrap_or(right).parse::<i64>().unwrap_or(0);
+            Ok((l ^ r) != 0)
+        }
+        Expr::Between { expr, low, high } => {
+            let v = values.get(expr).map(String::as_str).unwrap_or(expr).parse::<f64>().unwrap_or(0.0);
+            let l = values.get(low).map(String::as_str).unwrap_or(low).parse::<f64>().unwrap_or(0.0);
+            let h = values.get(high).map(String::as_str).unwrap_or(high).parse::<f64>().unwrap_or(0.0);
+            Ok(v >= l && v <= h)
         }
         Expr::GreaterThan { left, right } => {
             let l = values.get(left).map(String::as_str).unwrap_or(left).parse::<f64>().unwrap_or(0.0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,7 @@ fn main() -> io::Result<()> {
 mod tests {
     use super::*; // bring Catalog, Pager, BTree, etc. into scope
     use crate::sql::ast::evaluate_expression;
+    use crate::storage::row::ColumnValue;
     use crate::storage::row::ColumnType;
     use std::fs;
 
@@ -185,7 +186,7 @@ mod tests {
                         let v = val.to_string_value();
                         values.insert(col.clone(), v);
                     }
-                    if evaluate_expression(where_predicate.as_ref().unwrap(), &values) {
+                    if matches!(evaluate_expression(where_predicate.as_ref().unwrap(), &values), ColumnValue::Boolean(true)) {
                         found.push(row);
                     }
                 }

--- a/src/sql/ast.rs
+++ b/src/sql/ast.rs
@@ -5,6 +5,15 @@ use crate::storage::row::ColumnType;
 pub enum Expr {
     Equals { left: String, right: String },
     NotEquals { left: String, right: String },
+    Add { left: String, right: String },
+    Subtract { left: String, right: String },
+    Multiply { left: String, right: String },
+    Divide { left: String, right: String },
+    Modulo { left: String, right: String },
+    BitwiseAnd { left: String, right: String },
+    BitwiseOr { left: String, right: String },
+    BitwiseXor { left: String, right: String },
+    Between { expr: String, low: String, high: String },
     GreaterThan { left: String, right: String },
     GreaterOrEquals { left: String, right: String },
     LessThan { left: String, right: String },
@@ -158,34 +167,96 @@ use std::collections::HashMap;
 /// Evaluate an expression against a map of column values. If an operand
 /// matches a column name, the corresponding value is used; otherwise the
 /// operand itself is treated as a literal string.
-pub fn evaluate_expression(expr: &Expr, values: &HashMap<String, String>) -> bool {
+use crate::storage::row::ColumnValue;
+
+pub fn evaluate_expression(expr: &Expr, values: &HashMap<String, String>) -> ColumnValue {
     fn get_value<'a>(token: &'a str, values: &'a HashMap<String, String>) -> &'a str {
         values.get(token).map(String::as_str).unwrap_or(token)
     }
 
     match expr {
-        Expr::Equals { left, right } => get_value(left, values) == get_value(right, values),
-        Expr::NotEquals { left, right } => get_value(left, values) != get_value(right, values),
+        Expr::Equals { left, right } => ColumnValue::Boolean(get_value(left, values) == get_value(right, values)),
+        Expr::NotEquals { left, right } => ColumnValue::Boolean(get_value(left, values) != get_value(right, values)),
+        Expr::Add { left, right } => {
+            let l = get_value(left, values).parse::<i32>().unwrap_or(0);
+            let r = get_value(right, values).parse::<i32>().unwrap_or(0);
+            ColumnValue::Integer(l + r)
+        }
+        Expr::Subtract { left, right } => {
+            let l = get_value(left, values).parse::<i32>().unwrap_or(0);
+            let r = get_value(right, values).parse::<i32>().unwrap_or(0);
+            ColumnValue::Integer(l - r)
+        }
+        Expr::Multiply { left, right } => {
+            let l = get_value(left, values).parse::<i32>().unwrap_or(0);
+            let r = get_value(right, values).parse::<i32>().unwrap_or(0);
+            ColumnValue::Integer(l * r)
+        }
+        Expr::Divide { left, right } => {
+            let l = get_value(left, values).parse::<i32>().unwrap_or(0);
+            let r = get_value(right, values).parse::<i32>().unwrap_or(1);
+            if r == 0 { ColumnValue::Integer(0) } else { ColumnValue::Integer(l / r) }
+        }
+        Expr::Modulo { left, right } => {
+            let l = get_value(left, values).parse::<i32>().unwrap_or(0);
+            let r = get_value(right, values).parse::<i32>().unwrap_or(1);
+            if r == 0 { ColumnValue::Integer(0) } else { ColumnValue::Integer(l % r) }
+        }
+        Expr::BitwiseAnd { left, right } => {
+            let l = get_value(left, values).parse::<i32>().unwrap_or(0);
+            let r = get_value(right, values).parse::<i32>().unwrap_or(0);
+            ColumnValue::Integer(l & r)
+        }
+        Expr::BitwiseOr { left, right } => {
+            let l = get_value(left, values).parse::<i32>().unwrap_or(0);
+            let r = get_value(right, values).parse::<i32>().unwrap_or(0);
+            ColumnValue::Integer(l | r)
+        }
+        Expr::BitwiseXor { left, right } => {
+            let l = get_value(left, values).parse::<i32>().unwrap_or(0);
+            let r = get_value(right, values).parse::<i32>().unwrap_or(0);
+            ColumnValue::Integer(l ^ r)
+        }
+        Expr::Between { expr: v, low, high } => {
+            let val = get_value(v, values).parse::<f64>().unwrap_or(0.0);
+            let l = get_value(low, values).parse::<f64>().unwrap_or(0.0);
+            let h = get_value(high, values).parse::<f64>().unwrap_or(0.0);
+            ColumnValue::Boolean(val >= l && val <= h)
+        }
         Expr::GreaterThan { left, right } => {
-            get_value(left, values).parse::<f64>().unwrap_or(0.0)
-                > get_value(right, values).parse::<f64>().unwrap_or(0.0)
+            let l = get_value(left, values).parse::<f64>().unwrap_or(0.0);
+            let r = get_value(right, values).parse::<f64>().unwrap_or(0.0);
+            ColumnValue::Boolean(l > r)
         }
         Expr::GreaterOrEquals { left, right } => {
-            get_value(left, values).parse::<f64>().unwrap_or(0.0)
-                >= get_value(right, values).parse::<f64>().unwrap_or(0.0)
+            let l = get_value(left, values).parse::<f64>().unwrap_or(0.0);
+            let r = get_value(right, values).parse::<f64>().unwrap_or(0.0);
+            ColumnValue::Boolean(l >= r)
         }
         Expr::LessThan { left, right } => {
-            get_value(left, values).parse::<f64>().unwrap_or(0.0)
-                < get_value(right, values).parse::<f64>().unwrap_or(0.0)
+            let l = get_value(left, values).parse::<f64>().unwrap_or(0.0);
+            let r = get_value(right, values).parse::<f64>().unwrap_or(0.0);
+            ColumnValue::Boolean(l < r)
         }
         Expr::LessOrEquals { left, right } => {
-            get_value(left, values).parse::<f64>().unwrap_or(0.0)
-                <= get_value(right, values).parse::<f64>().unwrap_or(0.0)
+            let l = get_value(left, values).parse::<f64>().unwrap_or(0.0);
+            let r = get_value(right, values).parse::<f64>().unwrap_or(0.0);
+            ColumnValue::Boolean(l <= r)
         }
-        Expr::InSubquery { .. } | Expr::ExistsSubquery { .. } => false,
-        Expr::And(a, b) => evaluate_expression(a, values) && evaluate_expression(b, values),
-        Expr::Or(a, b) => evaluate_expression(a, values) || evaluate_expression(b, values),
-        Expr::Subquery(_) | Expr::Literal(_) | Expr::FunctionCall { .. } | Expr::DefaultValue => false,
+        Expr::InSubquery { .. } | Expr::ExistsSubquery { .. } => ColumnValue::Boolean(false),
+        Expr::And(a, b) => {
+            match (evaluate_expression(a, values), evaluate_expression(b, values)) {
+                (ColumnValue::Boolean(l), ColumnValue::Boolean(r)) => ColumnValue::Boolean(l && r),
+                _ => ColumnValue::Boolean(false),
+            }
+        }
+        Expr::Or(a, b) => {
+            match (evaluate_expression(a, values), evaluate_expression(b, values)) {
+                (ColumnValue::Boolean(l), ColumnValue::Boolean(r)) => ColumnValue::Boolean(l || r),
+                _ => ColumnValue::Boolean(false),
+            }
+        }
+        Expr::Subquery(_) | Expr::Literal(_) | Expr::FunctionCall { .. } | Expr::DefaultValue => ColumnValue::Boolean(false),
     }
 }
 

--- a/src/sql/parser.rs
+++ b/src/sql/parser.rs
@@ -146,6 +146,60 @@ fn parse_expression(tokens: &[&str]) -> Result<(Expr, usize), String> {
             consumed = 3;
             Expr::NotEquals { left, right }
         }
+        "<>" => {
+            let right = tokens[2].trim_end_matches(';').to_string();
+            consumed = 3;
+            Expr::NotEquals { left, right }
+        }
+        "+" => {
+            let right = tokens[2].trim_end_matches(';').to_string();
+            consumed = 3;
+            Expr::Add { left, right }
+        }
+        "-" => {
+            let right = tokens[2].trim_end_matches(';').to_string();
+            consumed = 3;
+            Expr::Subtract { left, right }
+        }
+        "*" => {
+            let right = tokens[2].trim_end_matches(';').to_string();
+            consumed = 3;
+            Expr::Multiply { left, right }
+        }
+        "/" => {
+            let right = tokens[2].trim_end_matches(';').to_string();
+            consumed = 3;
+            Expr::Divide { left, right }
+        }
+        "%" => {
+            let right = tokens[2].trim_end_matches(';').to_string();
+            consumed = 3;
+            Expr::Modulo { left, right }
+        }
+        "&" => {
+            let right = tokens[2].trim_end_matches(';').to_string();
+            consumed = 3;
+            Expr::BitwiseAnd { left, right }
+        }
+        "|" => {
+            let right = tokens[2].trim_end_matches(';').to_string();
+            consumed = 3;
+            Expr::BitwiseOr { left, right }
+        }
+        "^" => {
+            let right = tokens[2].trim_end_matches(';').to_string();
+            consumed = 3;
+            Expr::BitwiseXor { left, right }
+        }
+        "BETWEEN" => {
+            if tokens.len() < 5 || !tokens[3].eq_ignore_ascii_case("AND") {
+                return Err("BETWEEN requires syntax: <expr> BETWEEN <low> AND <high>".into());
+            }
+            let low = tokens[2].to_string();
+            let high = tokens[4].trim_end_matches(';').to_string();
+            consumed = 5;
+            Expr::Between { expr: left, low, high }
+        }
         ">" => {
             let right = tokens[2].trim_end_matches(';').to_string();
             consumed = 3;

--- a/tests/operators.rs
+++ b/tests/operators.rs
@@ -1,0 +1,109 @@
+use aerodb::sql::{ast::{Expr, Statement}, parser::parse_statement};
+use aerodb::storage::row::ColumnValue;
+use std::collections::HashMap;
+
+#[test]
+fn parse_not_equals_angle_brackets() {
+    let stmt = parse_statement("SELECT id FROM users WHERE id <> 5").unwrap();
+    if let Statement::Select { where_predicate: Some(pred), .. } = stmt {
+        match pred {
+            Expr::NotEquals { left, right } => {
+                assert_eq!(left, "id");
+                assert_eq!(right, "5");
+            }
+            _ => panic!("expected NotEquals"),
+        }
+    } else { panic!("expected select") }
+}
+
+#[test]
+fn parse_between_expression() {
+    let stmt = parse_statement("SELECT id FROM users WHERE id BETWEEN 1 AND 3").unwrap();
+    if let Statement::Select { where_predicate: Some(pred), .. } = stmt {
+        match pred {
+            Expr::Between { expr, low, high } => {
+                assert_eq!(expr, "id");
+                assert_eq!(low, "1");
+                assert_eq!(high, "3");
+            }
+            _ => panic!("expected Between"),
+        }
+    } else { panic!("expected select") }
+}
+
+#[test]
+fn evaluate_between_true() {
+    let expr = Expr::Between { expr: "5".into(), low: "1".into(), high: "10".into() };
+    assert_eq!(
+        aerodb::sql::ast::evaluate_expression(&expr, &HashMap::new()),
+        ColumnValue::Boolean(true)
+    );
+}
+
+#[test]
+fn evaluate_addition_nonzero() {
+    let expr = Expr::Add { left: "2".into(), right: "3".into() };
+    assert_eq!(
+        aerodb::sql::ast::evaluate_expression(&expr, &HashMap::new()),
+        ColumnValue::Integer(5)
+    );
+    let expr2 = Expr::Add { left: "2".into(), right: "-2".into() };
+    assert_eq!(
+        aerodb::sql::ast::evaluate_expression(&expr2, &HashMap::new()),
+        ColumnValue::Integer(0)
+    );
+}
+
+#[test]
+fn evaluate_multiplication_value() {
+    let expr = Expr::Multiply { left: "4".into(), right: "5".into() };
+    assert_eq!(
+        aerodb::sql::ast::evaluate_expression(&expr, &HashMap::new()),
+        ColumnValue::Integer(20)
+    );
+}
+
+#[test]
+fn evaluate_division_value() {
+    let expr = Expr::Divide { left: "10".into(), right: "2".into() };
+    assert_eq!(
+        aerodb::sql::ast::evaluate_expression(&expr, &HashMap::new()),
+        ColumnValue::Integer(5)
+    );
+}
+
+#[test]
+fn evaluate_modulo_value() {
+    let expr = Expr::Modulo { left: "10".into(), right: "3".into() };
+    assert_eq!(
+        aerodb::sql::ast::evaluate_expression(&expr, &HashMap::new()),
+        ColumnValue::Integer(1)
+    );
+}
+
+#[test]
+fn evaluate_bitwise_and_value() {
+    let expr = Expr::BitwiseAnd { left: "6".into(), right: "3".into() };
+    assert_eq!(
+        aerodb::sql::ast::evaluate_expression(&expr, &HashMap::new()),
+        ColumnValue::Integer(6 & 3)
+    );
+}
+
+#[test]
+fn evaluate_bitwise_or_value() {
+    let expr = Expr::BitwiseOr { left: "4".into(), right: "1".into() };
+    assert_eq!(
+        aerodb::sql::ast::evaluate_expression(&expr, &HashMap::new()),
+        ColumnValue::Integer(5)
+    );
+}
+
+#[test]
+fn evaluate_bitwise_xor_value() {
+    let expr = Expr::BitwiseXor { left: "6".into(), right: "3".into() };
+    assert_eq!(
+        aerodb::sql::ast::evaluate_expression(&expr, &HashMap::new()),
+        ColumnValue::Integer(5)
+    );
+}


### PR DESCRIPTION
## Summary
- support arithmetic and bitwise operators in expressions
- parse `<>` as `NOT EQUAL` and `BETWEEN` range checks
- evaluate the new operators
- evaluate expressions to numeric results instead of booleans
- test added operators

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684adbf782288333a6380aeea28449ee