### PR TITLE
Implement aliases in AeroDB

### DIFF
--- a/src/execution/runtime.rs
+++ b/src/execution/runtime.rs
@@ -777,8 +777,10 @@ pub fn handle_statement(catalog: &mut Catalog, stmt: Statement) -> DbResult<()> 
                 }
                 return Ok(());
             }
-            let from_table = match from.first().unwrap() {
-                crate::sql::ast::TableRef::Named { name, .. } => name.clone(),
+            let (from_table, base_alias) = match from.first().unwrap() {
+                crate::sql::ast::TableRef::Named { name, alias } => {
+                    (name.clone(), alias.clone())
+                }
                 _ => unreachable!(),
             };
             if joins.is_empty() {
@@ -814,7 +816,7 @@ pub fn handle_statement(catalog: &mut Catalog, stmt: Statement) -> DbResult<()> 
                     }
                 }
             } else {
-                let plan = crate::execution::plan::MultiJoinPlan { base_table: from_table, base_alias: None, joins, projections: columns.clone(), where_predicate };
+                let plan = crate::execution::plan::MultiJoinPlan { base_table: from_table, base_alias, joins, projections: columns.clone(), where_predicate };
                 let projections = expand_join_projections(&plan, catalog)?;
                 let header_meta = join_header(&plan, catalog, &projections)?;
                 println!("{}", format_header(&header_meta));

--- a/src/sql/ast.rs
+++ b/src/sql/ast.rs
@@ -106,13 +106,19 @@ impl AggFunc {
 }
 
 #[derive(Debug, Clone)]
-pub enum SelectExpr {
+pub enum SelectItem {
     All,
     Column(String),
     Aggregate { func: AggFunc, column: Option<String> },
     Expr(Box<Expr>),
     Subquery(Box<Statement>),
     Literal(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct SelectExpr {
+    pub expr: SelectItem,
+    pub alias: Option<String>,
 }
 pub type Predicate = Expr;
 

--- a/tests/alias.rs
+++ b/tests/alias.rs
@@ -1,0 +1,131 @@
+use aerodb::{catalog::Catalog, storage::pager::Pager, sql::{parser::parse_statement, ast::{Statement, ColumnDef}}, execution::runtime::{execute_select_statement, format_header}, storage::row::ColumnType};
+use std::fs;
+
+fn setup_catalog(filename: &str) -> Catalog {
+    let _ = fs::remove_file(filename);
+    let _ = fs::remove_file(format!("{}.wal", filename));
+    Catalog::open(Pager::new(filename).unwrap()).unwrap()
+}
+
+#[test]
+fn column_aliases() {
+    let filename = "test_column_aliases.db";
+    let mut catalog = setup_catalog(filename);
+    aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
+        table_name: "employees".into(),
+        columns: vec![
+            ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false },
+            ColumnDef { name: "first_name".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false, primary_key: false },
+            ColumnDef { name: "last_name".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false, primary_key: false },
+        ],
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
+    }).unwrap();
+    aerodb::execution::handle_statement(&mut catalog, parse_statement("INSERT INTO employees VALUES (1, 'John', 'Doe')").unwrap()).unwrap();
+    let stmt = parse_statement("SELECT first_name AS fname, last_name lname FROM employees").unwrap();
+    if let Statement::Select { .. } = stmt {
+        let mut out = Vec::new();
+        let header = execute_select_statement(&mut catalog, &stmt, &mut out, None).unwrap();
+        assert_eq!(format_header(&header), "fname TEXT | lname TEXT");
+        assert_eq!(out, vec![vec!["John".to_string(), "Doe".to_string()]]);
+    } else { panic!("expected select") }
+}
+
+#[test]
+fn table_aliases() {
+    let filename = "test_table_aliases.db";
+    let mut catalog = setup_catalog(filename);
+    aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
+        table_name: "employees".into(),
+        columns: vec![
+            ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false },
+            ColumnDef { name: "first_name".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false, primary_key: false },
+            ColumnDef { name: "department_id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false },
+        ],
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
+    }).unwrap();
+    aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
+        table_name: "departments".into(),
+        columns: vec![
+            ColumnDef { name: "department_id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false },
+            ColumnDef { name: "department_name".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false, primary_key: false },
+        ],
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
+    }).unwrap();
+    aerodb::execution::handle_statement(&mut catalog, parse_statement("INSERT INTO employees VALUES (1, 'John', 1)").unwrap()).unwrap();
+    aerodb::execution::handle_statement(&mut catalog, parse_statement("INSERT INTO departments VALUES (1, 'Sales')").unwrap()).unwrap();
+    let stmt = parse_statement("SELECT e.first_name, d.department_name FROM employees AS e JOIN departments d ON e.department_id = d.department_id").unwrap();
+    if let Statement::Select { columns, from, joins, where_predicate, .. } = stmt {
+        let (base_table, base_alias) = match from.first().unwrap() { aerodb::sql::ast::TableRef::Named { name, alias } => (name.clone(), alias.clone()), _ => panic!("expected table") };
+        let plan = aerodb::execution::plan::MultiJoinPlan { base_table, base_alias, joins, projections: columns, where_predicate };
+        let mut out = Vec::new();
+        aerodb::execution::runtime::execute_multi_join(&plan, &mut catalog, &mut out).unwrap();
+        assert_eq!(out, vec![vec!["John".to_string(), "Sales".to_string()]]);
+    } else { panic!("expected select") }
+}
+
+#[test]
+fn mixed_aliases() {
+    let filename = "test_mixed_aliases.db";
+    let mut catalog = setup_catalog(filename);
+    aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
+        table_name: "employees".into(),
+        columns: vec![
+            ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false },
+            ColumnDef { name: "first_name".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false, primary_key: false },
+            ColumnDef { name: "last_name".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false, primary_key: false },
+            ColumnDef { name: "department_id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false },
+        ],
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
+    }).unwrap();
+    aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
+        table_name: "departments".into(),
+        columns: vec![
+            ColumnDef { name: "department_id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false },
+            ColumnDef { name: "department_name".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false, primary_key: false },
+        ],
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
+    }).unwrap();
+    aerodb::execution::handle_statement(&mut catalog, parse_statement("INSERT INTO employees VALUES (1, 'John', 'Doe', 1)").unwrap()).unwrap();
+    aerodb::execution::handle_statement(&mut catalog, parse_statement("INSERT INTO departments VALUES (1, 'Sales')").unwrap()).unwrap();
+    let stmt = parse_statement("SELECT e.first_name fname, e.last_name lname, d.department_name dept FROM employees e JOIN departments d ON e.department_id = d.department_id").unwrap();
+    if let Statement::Select { columns, from, joins, where_predicate, .. } = stmt {
+        let (base_table, base_alias) = match from.first().unwrap() { aerodb::sql::ast::TableRef::Named { name, alias } => (name.clone(), alias.clone()), _ => panic!("expected table") };
+        let plan = aerodb::execution::plan::MultiJoinPlan { base_table, base_alias, joins, projections: columns, where_predicate };
+        let mut out = Vec::new();
+        aerodb::execution::runtime::execute_multi_join(&plan, &mut catalog, &mut out).unwrap();
+        assert_eq!(out, vec![vec!["John".to_string(), "Doe".to_string(), "Sales".to_string()]]);
+    } else { panic!("expected select") }
+}
+
+#[test]
+fn subquery_alias() {
+    let filename = "test_subquery_alias.db";
+    let mut catalog = setup_catalog(filename);
+    aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
+        table_name: "employees".into(),
+        columns: vec![
+            ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false },
+            ColumnDef { name: "department_id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false },
+            ColumnDef { name: "salary".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false },
+        ],
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
+    }).unwrap();
+    let data = vec![
+        (1, 1, 100),
+        (2, 1, 300),
+        (3, 2, 200),
+    ];
+    for (id, dept, sal) in data {
+        aerodb::execution::handle_statement(&mut catalog, parse_statement(&format!("INSERT INTO employees VALUES ({}, {}, {})", id, dept, sal)).unwrap()).unwrap();
+    }
+    let query = "SELECT avg.dept_id, avg.avg_salary FROM ( SELECT department_id dept_id, AVG(salary) avg_salary FROM employees GROUP BY department_id ) avg";
+    let stmt = parse_statement(query).unwrap();
+    if let Statement::Select { .. } = stmt {
+        let mut out = Vec::new();
+        let header = execute_select_statement(&mut catalog, &stmt, &mut out, None).unwrap();
+        out.sort();
+        assert_eq!(format_header(&header), "dept_id INTEGER | avg_salary INTEGER");
+        assert_eq!(out, vec![vec!["1".to_string(), "200".to_string()], vec!["2".to_string(), "200".to_string()]]);
+    } else { panic!("expected select") }
+}
+

--- a/tests/multi_join.rs
+++ b/tests/multi_join.rs
@@ -46,7 +46,7 @@ fn join_two_tables() {
     let stmt = parse_statement("SELECT a.v, b.w FROM a JOIN b ON a.id = b.a_id").unwrap();
     if let Statement::Select { columns, from, joins, where_predicate, .. } = stmt {
         let base_table = match from.first().unwrap() { aerodb::sql::ast::TableRef::Named { name, .. } => name.clone(), _ => panic!("expected table") };
-        let plan = aerodb::execution::plan::MultiJoinPlan { base_table, joins, projections: columns, where_predicate };
+        let plan = aerodb::execution::plan::MultiJoinPlan { base_table, base_alias: None, joins, projections: columns, where_predicate };
         let mut results = Vec::new();
         execute_multi_join(&plan, &mut catalog, &mut results).unwrap();
         assert_eq!(results.len(), 3);
@@ -93,7 +93,7 @@ fn join_three_tables() {
     let stmt = parse_statement("SELECT a.v, b.w, c.x FROM a JOIN b ON a.id = b.a_id JOIN c ON b.id = c.b_id").unwrap();
     if let Statement::Select { columns, from, joins, where_predicate, .. } = stmt {
         let base_table = match from.first().unwrap() { aerodb::sql::ast::TableRef::Named { name, .. } => name.clone(), _ => panic!("expected table") };
-        let plan = aerodb::execution::plan::MultiJoinPlan { base_table, joins, projections: columns, where_predicate };
+        let plan = aerodb::execution::plan::MultiJoinPlan { base_table, base_alias: None, joins, projections: columns, where_predicate };
         let mut results = Vec::new();
         execute_multi_join(&plan, &mut catalog, &mut results).unwrap();
         assert_eq!(results.len(), 2);
@@ -129,7 +129,7 @@ fn join_with_where() {
     let stmt = parse_statement("SELECT a.v, b.w FROM a JOIN b ON a.id = b.a_id WHERE a.v = av1").unwrap();
     if let Statement::Select { columns, from, joins, where_predicate, .. } = stmt {
         let base_table = match from.first().unwrap() { aerodb::sql::ast::TableRef::Named { name, .. } => name.clone(), _ => panic!("expected table") };
-        let plan = aerodb::execution::plan::MultiJoinPlan { base_table, joins, projections: columns, where_predicate };
+        let plan = aerodb::execution::plan::MultiJoinPlan { base_table, base_alias: None, joins, projections: columns, where_predicate };
         let mut results = Vec::new();
         execute_multi_join(&plan, &mut catalog, &mut results).unwrap();
         assert_eq!(results.len(), 1);

--- a/tests/nested_queries.rs
+++ b/tests/nested_queries.rs
@@ -181,7 +181,7 @@ fn execute_exists_constant() {
 fn parse_select_subquery() {
     let stmt = parse_statement("SELECT name, (SELECT COUNT(*) FROM orders WHERE orders.user_id = users.id) FROM users").unwrap();
     if let Statement::Select { columns, .. } = stmt {
-        assert!(matches!(columns[1], SelectExpr::Subquery(_)));
+        assert!(matches!(columns[1].expr, aerodb::sql::ast::SelectItem::Subquery(_)));
     } else { panic!("expected select"); }
 }
 

--- a/tests/select_expressions.rs
+++ b/tests/select_expressions.rs
@@ -12,7 +12,7 @@ fn parse_select_add_expr() {
     let stmt = parse_statement("SELECT val + 5 FROM numbers").unwrap();
     if let Statement::Select { columns, .. } = stmt {
         match &columns[0] {
-            SelectExpr::Expr(expr_box) => match **expr_box {
+            SelectExpr { expr: aerodb::sql::ast::SelectItem::Expr(expr_box), .. } => match **expr_box {
                 Expr::Add { ref left, ref right } => {
                     assert_eq!(left, "val");
                     assert_eq!(right, "5");


### PR DESCRIPTION
## Summary
- support aliasing in SQL parser via new `SelectItem` and `SelectExpr` structures
- propagate table and column aliases through execution planning
- adjust runtime join handling for table aliases
- add regression tests for column, table and subquery alias usage