### PR TITLE
Fix floating point expressions

### DIFF
--- a/src/execution/runtime.rs
+++ b/src/execution/runtime.rs
@@ -921,7 +921,7 @@ pub fn select_projection_indices(
                     idxs.push(Projection::Literal(val.clone()));
                 }
                 SelectItem::Expr(expr) => {
-                    meta.push((p.alias.clone().unwrap_or("EXPR".into()), ColumnType::Integer));
+                    meta.push((p.alias.clone().unwrap_or("EXPR".into()), ColumnType::Double { precision: 8, scale: 2, unsigned: false }));
                     idxs.push(Projection::Expr(expr.clone()));
                 }
             }
@@ -1008,29 +1008,29 @@ fn evaluate_with_catalog(
                 != values.get(right).map(String::as_str).unwrap_or(right))
         }
         Expr::Add { left, right } => {
-            let l = values.get(left).map(String::as_str).unwrap_or(left).parse::<i64>().unwrap_or(0);
-            let r = values.get(right).map(String::as_str).unwrap_or(right).parse::<i64>().unwrap_or(0);
-            Ok(l + r != 0)
+            let l = values.get(left).map(String::as_str).unwrap_or(left).parse::<f64>().unwrap_or(0.0);
+            let r = values.get(right).map(String::as_str).unwrap_or(right).parse::<f64>().unwrap_or(0.0);
+            Ok((l + r) != 0.0)
         }
         Expr::Subtract { left, right } => {
-            let l = values.get(left).map(String::as_str).unwrap_or(left).parse::<i64>().unwrap_or(0);
-            let r = values.get(right).map(String::as_str).unwrap_or(right).parse::<i64>().unwrap_or(0);
-            Ok(l - r != 0)
+            let l = values.get(left).map(String::as_str).unwrap_or(left).parse::<f64>().unwrap_or(0.0);
+            let r = values.get(right).map(String::as_str).unwrap_or(right).parse::<f64>().unwrap_or(0.0);
+            Ok((l - r) != 0.0)
         }
         Expr::Multiply { left, right } => {
-            let l = values.get(left).map(String::as_str).unwrap_or(left).parse::<i64>().unwrap_or(0);
-            let r = values.get(right).map(String::as_str).unwrap_or(right).parse::<i64>().unwrap_or(0);
-            Ok(l * r != 0)
+            let l = values.get(left).map(String::as_str).unwrap_or(left).parse::<f64>().unwrap_or(0.0);
+            let r = values.get(right).map(String::as_str).unwrap_or(right).parse::<f64>().unwrap_or(0.0);
+            Ok((l * r) != 0.0)
         }
         Expr::Divide { left, right } => {
-            let l = values.get(left).map(String::as_str).unwrap_or(left).parse::<i64>().unwrap_or(0);
-            let r = values.get(right).map(String::as_str).unwrap_or(right).parse::<i64>().unwrap_or(1);
-            if r == 0 { Ok(false) } else { Ok(l / r != 0) }
+            let l = values.get(left).map(String::as_str).unwrap_or(left).parse::<f64>().unwrap_or(0.0);
+            let r = values.get(right).map(String::as_str).unwrap_or(right).parse::<f64>().unwrap_or(1.0);
+            if r == 0.0 { Ok(false) } else { Ok((l / r) != 0.0) }
         }
         Expr::Modulo { left, right } => {
-            let l = values.get(left).map(String::as_str).unwrap_or(left).parse::<i64>().unwrap_or(0);
-            let r = values.get(right).map(String::as_str).unwrap_or(right).parse::<i64>().unwrap_or(1);
-            if r == 0 { Ok(false) } else { Ok(l % r != 0) }
+            let l = values.get(left).map(String::as_str).unwrap_or(left).parse::<f64>().unwrap_or(0.0);
+            let r = values.get(right).map(String::as_str).unwrap_or(right).parse::<f64>().unwrap_or(1.0);
+            if r == 0.0 { Ok(false) } else { Ok((l % r) != 0.0) }
         }
         Expr::BitwiseAnd { left, right } => {
             let l = values.get(left).map(String::as_str).unwrap_or(left).parse::<i64>().unwrap_or(0);

--- a/src/sql/ast.rs
+++ b/src/sql/ast.rs
@@ -185,29 +185,29 @@ pub fn evaluate_expression(expr: &Expr, values: &HashMap<String, String>) -> Col
         Expr::Equals { left, right } => ColumnValue::Boolean(get_value(left, values) == get_value(right, values)),
         Expr::NotEquals { left, right } => ColumnValue::Boolean(get_value(left, values) != get_value(right, values)),
         Expr::Add { left, right } => {
-            let l = get_value(left, values).parse::<i32>().unwrap_or(0);
-            let r = get_value(right, values).parse::<i32>().unwrap_or(0);
-            ColumnValue::Integer(l + r)
+            let l = get_value(left, values).parse::<f64>().unwrap_or(0.0);
+            let r = get_value(right, values).parse::<f64>().unwrap_or(0.0);
+            ColumnValue::Double(l + r)
         }
         Expr::Subtract { left, right } => {
-            let l = get_value(left, values).parse::<i32>().unwrap_or(0);
-            let r = get_value(right, values).parse::<i32>().unwrap_or(0);
-            ColumnValue::Integer(l - r)
+            let l = get_value(left, values).parse::<f64>().unwrap_or(0.0);
+            let r = get_value(right, values).parse::<f64>().unwrap_or(0.0);
+            ColumnValue::Double(l - r)
         }
         Expr::Multiply { left, right } => {
-            let l = get_value(left, values).parse::<i32>().unwrap_or(0);
-            let r = get_value(right, values).parse::<i32>().unwrap_or(0);
-            ColumnValue::Integer(l * r)
+            let l = get_value(left, values).parse::<f64>().unwrap_or(0.0);
+            let r = get_value(right, values).parse::<f64>().unwrap_or(0.0);
+            ColumnValue::Double(l * r)
         }
         Expr::Divide { left, right } => {
-            let l = get_value(left, values).parse::<i32>().unwrap_or(0);
-            let r = get_value(right, values).parse::<i32>().unwrap_or(1);
-            if r == 0 { ColumnValue::Integer(0) } else { ColumnValue::Integer(l / r) }
+            let l = get_value(left, values).parse::<f64>().unwrap_or(0.0);
+            let r = get_value(right, values).parse::<f64>().unwrap_or(1.0);
+            if r == 0.0 { ColumnValue::Double(0.0) } else { ColumnValue::Double(l / r) }
         }
         Expr::Modulo { left, right } => {
-            let l = get_value(left, values).parse::<i32>().unwrap_or(0);
-            let r = get_value(right, values).parse::<i32>().unwrap_or(1);
-            if r == 0 { ColumnValue::Integer(0) } else { ColumnValue::Integer(l % r) }
+            let l = get_value(left, values).parse::<f64>().unwrap_or(0.0);
+            let r = get_value(right, values).parse::<f64>().unwrap_or(1.0);
+            if r == 0.0 { ColumnValue::Double(0.0) } else { ColumnValue::Double(l % r) }
         }
         Expr::BitwiseAnd { left, right } => {
             let l = get_value(left, values).parse::<i32>().unwrap_or(0);

--- a/tests/operators.rs
+++ b/tests/operators.rs
@@ -45,12 +45,12 @@ fn evaluate_addition_nonzero() {
     let expr = Expr::Add { left: "2".into(), right: "3".into() };
     assert_eq!(
         aerodb::sql::ast::evaluate_expression(&expr, &HashMap::new()),
-        ColumnValue::Integer(5)
+        ColumnValue::Double(5.0)
     );
     let expr2 = Expr::Add { left: "2".into(), right: "-2".into() };
     assert_eq!(
         aerodb::sql::ast::evaluate_expression(&expr2, &HashMap::new()),
-        ColumnValue::Integer(0)
+        ColumnValue::Double(0.0)
     );
 }
 
@@ -59,7 +59,7 @@ fn evaluate_multiplication_value() {
     let expr = Expr::Multiply { left: "4".into(), right: "5".into() };
     assert_eq!(
         aerodb::sql::ast::evaluate_expression(&expr, &HashMap::new()),
-        ColumnValue::Integer(20)
+        ColumnValue::Double(20.0)
     );
 }
 
@@ -68,7 +68,7 @@ fn evaluate_division_value() {
     let expr = Expr::Divide { left: "10".into(), right: "2".into() };
     assert_eq!(
         aerodb::sql::ast::evaluate_expression(&expr, &HashMap::new()),
-        ColumnValue::Integer(5)
+        ColumnValue::Double(5.0)
     );
 }
 
@@ -77,7 +77,7 @@ fn evaluate_modulo_value() {
     let expr = Expr::Modulo { left: "10".into(), right: "3".into() };
     assert_eq!(
         aerodb::sql::ast::evaluate_expression(&expr, &HashMap::new()),
-        ColumnValue::Integer(1)
+        ColumnValue::Double(1.0)
     );
 }
 

--- a/tests/select_expressions.rs
+++ b/tests/select_expressions.rs
@@ -44,3 +44,23 @@ fn execute_select_add_expr() {
         assert_eq!(out, vec![vec![String::from("15")]]);
     } else { panic!("expected select") }
 }
+#[test]
+fn execute_select_mul_double_expr() {
+    let filename = "test_select_mul_double_expr.db";
+    let mut catalog = setup_catalog(filename);
+    handle_statement(&mut catalog, Statement::CreateTable {
+        table_name: "orders".into(),
+        columns: vec![
+            ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false },
+            ColumnDef { name: "total".into(), col_type: ColumnType::Double { precision: 8, scale: 2, unsigned: true }, not_null: false, default_value: None, auto_increment: false, primary_key: false },
+        ],
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
+    }).unwrap();
+    handle_statement(&mut catalog, parse_statement("INSERT INTO orders VALUES (1, 20.0)").unwrap()).unwrap();
+    let stmt = parse_statement("SELECT id, total * 1.05 FROM orders WHERE id = 1").unwrap();
+    if let Statement::Select { .. } = stmt {
+        let mut out = Vec::new();
+        let _header = execute_select_statement(&mut catalog, &stmt, &mut out, None).unwrap();
+        assert_eq!(out, vec![vec![String::from("1"), String::from("21")]]);
+    } else { panic!("expected select") }
+}


### PR DESCRIPTION
## Summary
- handle floating point math in expression evaluator
- mark expression result columns as DOUBLE
- add test for multiplying doubles
- adjust operator tests for new return types
