### PR TITLE
Fix HAVING with aliased aggregates

### DIFF
--- a/src/execution/runtime.rs
+++ b/src/execution/runtime.rs
@@ -548,7 +548,11 @@ pub fn execute_group_query(
                         }
                     };
                     let name = format!("{}({})", func.as_str(), column.clone().unwrap_or("*".into()));
-                    value_map.insert(expr.alias.clone().unwrap_or(name.clone()), val.clone());
+                    let key = expr.alias.clone().unwrap_or(name.clone());
+                    value_map.insert(key, val.clone());
+                    if expr.alias.is_some() {
+                        value_map.insert(name, val.clone());
+                    }
                     result_row.push(val);
                 }
                 SelectItem::All => {

--- a/tests/having.rs
+++ b/tests/having.rs
@@ -137,3 +137,30 @@ fn having_sum_double() {
         assert!(out.is_empty());
     } else { panic!("expected select") }
 }
+
+#[test]
+fn having_ignores_alias() {
+    let filename = "test_having_alias.db";
+    let mut catalog = setup_catalog(filename);
+    aerodb::execution::handle_statement(&mut catalog, Statement::CreateTable {
+        table_name: "orders".into(),
+        columns: vec![
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "user_id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+            aerodb::sql::ast::ColumnDef { name: "total".into(), col_type: ColumnType::Double { precision: 10, scale: 2, unsigned: true }, not_null: false, default_value: None, auto_increment: false, primary_key: false},
+        ],
+        fks: Vec::new(), primary_key: None, if_not_exists: false,
+    }).unwrap();
+    aerodb::execution::handle_statement(&mut catalog, parse_statement("INSERT INTO orders VALUES (1, 2, 20)").unwrap()).unwrap();
+    let stmt = parse_statement("SELECT user_id, SUM(total) AS total_spent FROM orders GROUP BY user_id HAVING SUM(total) > 3").unwrap();
+    if let Statement::Select { columns, from, group_by, having: Some(have), .. } = stmt {
+        let table = match from.first().unwrap() {
+            aerodb::sql::ast::TableRef::Named { name, .. } => name,
+            _ => panic!("expected table"),
+        };
+        let mut out = Vec::new();
+        let header = execute_group_query(&mut catalog, table, &columns, group_by.as_deref(), Some(have), None, &mut out, None).unwrap();
+        assert_eq!(format_header(&header), "user_id INTEGER | total_spent INTEGER");
+        assert_eq!(out, vec![vec!["2".to_string(), "20".to_string()]]);
+    } else { panic!("expected select") }
+}


### PR DESCRIPTION
## Summary
- keep aggregate function name available when aliasing
- test HAVING with SUM when column is aliased

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684c73801cd88333a55c023604e90f72