### PR TITLE
Implement DROP INDEX support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ SELECT * FROM users;
 
 The resulting output will list all inserted rows. See the `tests/` directory for additional query examples.
 
+## Schema Changes
+
+The engine supports basic DDL operations:
+
+```sql
+CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
+CREATE INDEX idx_name ON users(name);
+DROP INDEX idx_name;
+DROP TABLE users;
+```
+
+`DROP INDEX` removes the specified index from the catalog so new queries fall back to full table scans when appropriate.
+
 ## Project Structure
 
 - `src/` – Rust source code for the database engine.

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,8 @@ pub enum DbError {
     InvalidValue(String),
     #[error("foreign key violation: {0}")]
     ForeignKeyViolation(String),
+    #[error("{0} not found")]
+    NotFound(String),
     #[error(transparent)]
     Io(#[from] io::Error),
 }

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -25,6 +25,9 @@ pub fn execute_plan(plan: PlanNode /*, btree: &mut storage::BTree */) {
                 index_name, table_name, column_name
             );
         }
+        PlanNode::DropIndex { name } => {
+            println!("Planning drop index {}", name);
+        }
         PlanNode::Select { table_name, selection, .. } => {
             println!("Executing: Select from {} where {:?}", table_name, selection);
             // In future: if let Some(row) = btree.find(key).unwrap() { ... }

--- a/src/execution/plan.rs
+++ b/src/execution/plan.rs
@@ -15,6 +15,9 @@ pub enum PlanNode {
         table_name: String,
         column_name: String,
     },
+    DropIndex {
+        name: String,
+    },
     DropTable {
         table_name: String,
         if_exists: bool,
@@ -86,6 +89,7 @@ pub fn plan_statement(stmt: Statement) -> PlanNode {
                 })
             }
         }
+        Statement::DropIndex { name } => PlanNode::DropIndex { name },
         Statement::DropTable { table_name, if_exists } => PlanNode::DropTable { table_name, if_exists },
         Statement::Delete { table_name, selection } => PlanNode::Delete { table_name, selection },
         Statement::Update { table_name, assignments, selection } => PlanNode::Update { table_name, assignments, selection },

--- a/src/execution/runtime.rs
+++ b/src/execution/runtime.rs
@@ -633,6 +633,13 @@ pub fn handle_statement(catalog: &mut Catalog, stmt: Statement) -> DbResult<()> 
             catalog.create_index(&index_name, &table_name, &column_name)?;
             println!("Index {} created", index_name);
         }
+        Statement::DropIndex { name } => {
+            if catalog.drop_index(&name)? {
+                println!("Index {} dropped", name);
+            } else {
+                return Err(DbError::NotFound(format!("index '{}' not found", name)));
+            }
+        }
         Statement::Insert { table_name, columns: col_list, values } => {
             let table_info = catalog.get_table(&table_name)?.clone();
             let root_page = table_info.root_page;

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,7 @@ fn main() -> io::Result<()> {
                         DbError::Overflow => println!("Error: value out of range"),
                         DbError::ParseError(m) | DbError::InvalidValue(m) => println!("Error: {}", m),
                         DbError::ColumnNotFound(c) => println!("Error: column '{}' not found", c),
+                        DbError::NotFound(m) => println!("Error: {}", m),
                         DbError::NullViolation(c) => println!("Error: column '{}' cannot be NULL", c),
                         DbError::ForeignKeyViolation(m) => println!("Error: {}", m),
                         DbError::Io(err) => println!("IO error: {}", err),

--- a/src/sql/ast.rs
+++ b/src/sql/ast.rs
@@ -136,6 +136,9 @@ pub enum Statement {
         table_name: String,
         column_name: String,
     },
+    DropIndex {
+        name: String,
+    },
     DropTable {
         table_name: String,
         if_exists: bool,

--- a/tests/drop_index.rs
+++ b/tests/drop_index.rs
@@ -1,0 +1,74 @@
+use aerodb::{catalog::Catalog, storage::pager::Pager, sql::{parser::parse_statement, ast::Statement}, execution::runtime::{handle_statement, execute_select_with_indexes}};
+use std::fs;
+
+fn setup_catalog(filename: &str) -> Catalog {
+    let _ = fs::remove_file(filename);
+    let _ = fs::remove_file(format!("{}.wal", filename));
+    Catalog::open(Pager::new(filename).unwrap()).unwrap()
+}
+
+#[test]
+fn drop_index_basic() {
+    let filename = "test_drop_index_basic.db";
+    let mut catalog = setup_catalog(filename);
+
+    handle_statement(&mut catalog, parse_statement("CREATE TABLE t (id INT, name TEXT)").unwrap()).unwrap();
+    handle_statement(&mut catalog, parse_statement("CREATE INDEX idx1 ON t (name)").unwrap()).unwrap();
+    handle_statement(&mut catalog, parse_statement("CREATE INDEX idx2 ON t (id)").unwrap()).unwrap();
+    let names: Vec<String> = catalog.all_indexes().into_iter().map(|i| i.name).collect();
+    assert!(names.contains(&"idx1".to_string()));
+    assert!(names.contains(&"idx2".to_string()));
+
+    handle_statement(&mut catalog, parse_statement("DROP INDEX idx1").unwrap()).unwrap();
+    let names: Vec<String> = catalog.all_indexes().into_iter().map(|i| i.name).collect();
+    assert!(!names.contains(&"idx1".to_string()));
+    assert!(names.contains(&"idx2".to_string()));
+}
+
+#[test]
+fn drop_table_cleans_indexes() {
+    let filename = "test_drop_table_cleans_indexes.db";
+    let mut catalog = setup_catalog(filename);
+
+    handle_statement(&mut catalog, parse_statement("CREATE TABLE t (id INT, name TEXT)").unwrap()).unwrap();
+    handle_statement(&mut catalog, parse_statement("CREATE INDEX idx1 ON t (name)").unwrap()).unwrap();
+    handle_statement(&mut catalog, parse_statement("CREATE INDEX idx2 ON t (id)").unwrap()).unwrap();
+
+    assert_eq!(catalog.all_indexes().len(), 2);
+    handle_statement(&mut catalog, parse_statement("DROP TABLE t").unwrap()).unwrap();
+    assert!(catalog.all_indexes().is_empty());
+
+    handle_statement(&mut catalog, parse_statement("CREATE TABLE t (id INT, name TEXT)").unwrap()).unwrap();
+    handle_statement(&mut catalog, parse_statement("CREATE INDEX idx1 ON t (name)").unwrap()).unwrap();
+    let names: Vec<String> = catalog.all_indexes().into_iter().map(|i| i.name).collect();
+    assert!(names.contains(&"idx1".to_string()));
+}
+
+#[test]
+fn selects_use_full_scan_after_drop() {
+    let filename = "test_drop_index_scan.db";
+    let mut catalog = setup_catalog(filename);
+
+    handle_statement(&mut catalog, parse_statement("CREATE TABLE t (id INT, name TEXT)").unwrap()).unwrap();
+    handle_statement(&mut catalog, parse_statement("CREATE INDEX idx1 ON t (name)").unwrap()).unwrap();
+    for i in 1..=3 {
+        handle_statement(&mut catalog, parse_statement(&format!("INSERT INTO t VALUES ({}, 'u{}')", i, i)).unwrap()).unwrap();
+    }
+
+    handle_statement(&mut catalog, parse_statement("DROP INDEX idx1").unwrap()).unwrap();
+    handle_statement(&mut catalog, parse_statement("INSERT INTO t VALUES (4, 'u2')").unwrap()).unwrap();
+
+    let stmt = parse_statement("SELECT * FROM t WHERE name = u2").unwrap();
+    if let Statement::Select { from, where_predicate, .. } = stmt {
+        let table_name = match from.first().unwrap() {
+            aerodb::sql::ast::TableRef::Named { name, .. } => name.clone(),
+            _ => panic!("expected table"),
+        };
+        let mut rows = Vec::new();
+        let used = execute_select_with_indexes(&mut catalog, &table_name, where_predicate, &mut rows).unwrap();
+        assert!(!used);
+        assert_eq!(rows.len(), 2);
+    } else {
+        panic!("expected select");
+    }
+}


### PR DESCRIPTION
## Summary
- add DROP INDEX statement variant and parser support
- implement Catalog::drop_index and cascade when dropping tables
- wire up runtime handling for index deletion
- add tests covering DROP INDEX behavior
- document DROP INDEX usage and schema change commands

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685aaa0f73b4833397526dfc22b2bc79