### PR TITLE
Enforce GROUP BY column validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ INSERT INTO tbl [(col,...)] VALUES (v1,...), (v2,...);
 
 The resulting output will list all inserted rows. See the `tests/` directory for additional query examples.
 
+## Query Language
+
+### GROUP BY
+
+AeroDB now enforces standard SQL grouping rules: every selected column must be aggregated or listed in GROUP BY.
+
 ## Schema Changes
 
 The engine supports basic DDL operations:

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,8 @@ pub enum DbError {
     InvalidValue(String),
     #[error("foreign key violation: {0}")]
     ForeignKeyViolation(String),
+    #[error("column '{0}' must appear in the GROUP BY clause or be used in an aggregate function")]
+    GroupByMismatch(String),
     #[error("{0} not found")]
     NotFound(String),
     #[error(transparent)]

--- a/src/execution/runtime.rs
+++ b/src/execution/runtime.rs
@@ -5,6 +5,7 @@ use crate::storage::btree::BTree;
 use crate::storage::row::{Row, RowData, ColumnValue, ColumnType, build_row_data};
 use std::collections::HashMap;
 use crate::error::{DbError, DbResult};
+use crate::planner::aggregate;
 
 pub fn execute_delete(catalog: &mut Catalog, table_name: &str, selection: Option<Expr>) -> DbResult<usize> {
     if let Ok(table_info) = catalog.get_table(table_name).map(Clone::clone) {
@@ -558,6 +559,7 @@ pub fn execute_group_query(
     let mut rows = Vec::new();
     execute_select_with_indexes(catalog, table_name, None, &mut rows)?;
     let table_info = catalog.get_table(table_name)?.clone();
+    aggregate::validate_group_by(projections, group_by, having.as_ref(), &table_info.columns)?;
 
     let mut groups: std::collections::HashMap<Vec<String>, Vec<crate::storage::row::Row>> = std::collections::HashMap::new();
     let mut col_pos = std::collections::HashMap::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,4 @@ pub mod execution;
 pub mod transaction;
 pub mod constraints;
 pub mod error;
+pub mod planner;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod execution;
 mod transaction;
 mod constraints;
 mod error;
+mod planner;
 
 use std::io::{self, Write};
 use log::{debug, info, warn};
@@ -58,6 +59,7 @@ fn main() -> io::Result<()> {
                         DbError::Overflow => println!("Error: value out of range"),
                         DbError::ParseError(m) | DbError::InvalidValue(m) => println!("Error: {}", m),
                         DbError::ColumnNotFound(c) => println!("Error: column '{}' not found", c),
+                        DbError::GroupByMismatch(c) => println!("Error: column '{}' must appear in GROUP BY or be aggregated", c),
                         DbError::NotFound(m) => println!("Error: {}", m),
                         DbError::NullViolation(c) => println!("Error: column '{}' cannot be NULL", c),
                         DbError::ForeignKeyViolation(m) => println!("Error: {}", m),

--- a/src/planner/aggregate.rs
+++ b/src/planner/aggregate.rs
@@ -1,0 +1,132 @@
+use std::collections::HashSet;
+
+use crate::error::{DbError, DbResult};
+use crate::sql::ast::{Expr, SelectExpr, SelectItem};
+use crate::storage::row::ColumnType;
+
+fn normalize(name: &str) -> String {
+    name.split('.').last().unwrap_or(name).to_ascii_uppercase()
+}
+
+fn is_agg_token(token: &str) -> bool {
+    let up = token.to_ascii_uppercase();
+    up.starts_with("SUM(") || up.starts_with("COUNT(") || up.starts_with("AVG(") || up.starts_with("MIN(") || up.starts_with("MAX(")
+}
+
+fn collect_expr_columns(expr: &Expr, cols: &HashSet<String>, out: &mut HashSet<String>, aggs: &mut bool) {
+    match expr {
+        Expr::Equals { left, right }
+        | Expr::NotEquals { left, right }
+        | Expr::Add { left, right }
+        | Expr::Subtract { left, right }
+        | Expr::Multiply { left, right }
+        | Expr::Divide { left, right }
+        | Expr::Modulo { left, right }
+        | Expr::BitwiseAnd { left, right }
+        | Expr::BitwiseOr { left, right }
+        | Expr::BitwiseXor { left, right }
+        | Expr::GreaterThan { left, right }
+        | Expr::GreaterOrEquals { left, right }
+        | Expr::LessThan { left, right }
+        | Expr::LessOrEquals { left, right } => {
+            for tok in [left, right] {
+                let n = normalize(tok);
+                if is_agg_token(tok) {
+                    *aggs = true;
+                } else if cols.contains(&n) {
+                    out.insert(n);
+                }
+            }
+        }
+        Expr::Between { expr, low, high } => {
+            collect_expr_columns(&Expr::GreaterOrEquals { left: expr.clone(), right: low.clone() }, cols, out, aggs);
+            collect_expr_columns(&Expr::LessOrEquals { left: expr.clone(), right: high.clone() }, cols, out, aggs);
+        }
+        Expr::And(a, b) | Expr::Or(a, b) => {
+            collect_expr_columns(a, cols, out, aggs);
+            collect_expr_columns(b, cols, out, aggs);
+        }
+        Expr::FunctionCall { name, args } => {
+            let tok = format!("{}(", name);
+            if is_agg_token(&tok) {
+                *aggs = true;
+            }
+            for a in args {
+                collect_expr_columns(a, cols, out, aggs);
+            }
+        }
+        Expr::InSubquery { .. } | Expr::ExistsSubquery { .. } | Expr::Subquery(_) => {}
+        Expr::Literal(_) | Expr::DefaultValue => {}
+    }
+}
+
+pub fn validate_group_by(
+    projections: &[SelectExpr],
+    group_by: Option<&[String]>,
+    having: Option<&Expr>,
+    table_columns: &[(String, ColumnType)],
+) -> DbResult<()> {
+    let col_set: HashSet<String> = table_columns.iter().map(|(c, _)| c.to_ascii_uppercase()).collect();
+    let mut group_cols: HashSet<String> = HashSet::new();
+    if let Some(gb) = group_by {
+        for c in gb {
+            group_cols.insert(normalize(c));
+        }
+    }
+    let mut agg_present = false;
+    let mut select_cols: HashSet<String> = HashSet::new();
+    let mut agg_cols: HashSet<String> = HashSet::new();
+    for expr in projections {
+        match &expr.expr {
+            SelectItem::Column(c) => {
+                let n = normalize(c);
+                select_cols.insert(n.clone());
+            }
+            SelectItem::Aggregate { column: Some(c), .. } => {
+                agg_present = true;
+                agg_cols.insert(normalize(c));
+            }
+            SelectItem::Aggregate { .. } => {
+                agg_present = true;
+            }
+            SelectItem::Expr(e) => {
+                let mut cols = HashSet::new();
+                collect_expr_columns(e, &col_set, &mut cols, &mut agg_present);
+                select_cols.extend(cols);
+            }
+            SelectItem::All => {
+                for c in &col_set {
+                    select_cols.insert(c.clone());
+                }
+            }
+            SelectItem::Subquery(_) | SelectItem::Literal(_) => {}
+        }
+    }
+
+    if let Some(have) = having {
+        let mut cols = HashSet::new();
+        collect_expr_columns(have, &col_set, &mut cols, &mut agg_present);
+        for c in cols {
+            if !group_cols.contains(&c) && !agg_cols.contains(&c) {
+                return Err(DbError::GroupByMismatch(c));
+            }
+        }
+    }
+
+    for c in &select_cols {
+        if !group_cols.contains(c) {
+            return Err(DbError::GroupByMismatch(c.clone()));
+        }
+    }
+
+    if !agg_present {
+        for c in &group_cols {
+            if !select_cols.contains(c) {
+                return Err(DbError::GroupByMismatch(c.clone()));
+            }
+        }
+    }
+
+    Ok(())
+}
+

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -1,0 +1,1 @@
+pub mod aggregate;

--- a/tests/group_by.rs
+++ b/tests/group_by.rs
@@ -1,0 +1,103 @@
+use aerodb::{catalog::Catalog, storage::pager::Pager, sql::{parser::parse_statement, ast::Statement}, execution::runtime::{execute_group_query, format_header}, storage::row::ColumnType};
+use std::fs;
+
+fn setup_catalog(filename: &str) -> Catalog {
+    let _ = fs::remove_file(filename);
+    let _ = fs::remove_file(format!("{}.wal", filename));
+    Catalog::open(Pager::new(filename).unwrap()).unwrap()
+}
+
+fn create_matches_table(catalog: &mut Catalog) {
+    aerodb::execution::handle_statement(catalog, Statement::CreateTable {
+        table_name: "matches".into(),
+        columns: vec![
+            aerodb::sql::ast::ColumnDef { name: "id".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false },
+            aerodb::sql::ast::ColumnDef { name: "team".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false, primary_key: false },
+            aerodb::sql::ast::ColumnDef { name: "league".into(), col_type: ColumnType::Text, not_null: false, default_value: None, auto_increment: false, primary_key: false },
+            aerodb::sql::ast::ColumnDef { name: "score".into(), col_type: ColumnType::Integer, not_null: false, default_value: None, auto_increment: false, primary_key: false },
+        ],
+        fks: Vec::new(),
+        primary_key: None,
+        if_not_exists: false,
+    }).unwrap();
+    let rows = vec![(1, "a", "l1", 10), (2, "a", "l2", 20), (3, "b", "l1", 15)];
+    for (id, team, league, score) in rows {
+        aerodb::execution::handle_statement(catalog, parse_statement(&format!("INSERT INTO matches VALUES ({}, '{}', '{}', {})", id, team, league, score)).unwrap()).unwrap();
+    }
+}
+
+#[test]
+fn grouped_column_ok() {
+    let filename = "test_group_ok.db";
+    let mut catalog = setup_catalog(filename);
+    create_matches_table(&mut catalog);
+    let stmt = parse_statement("SELECT team, SUM(score) FROM matches GROUP BY team").unwrap();
+    if let Statement::Select { columns, from, group_by, .. } = stmt {
+        let table = match from.first().unwrap() { aerodb::sql::ast::TableRef::Named { name, .. } => name, _ => panic!("expected table") };
+        let mut out = Vec::new();
+        let header = execute_group_query(&mut catalog, table, &columns, group_by.as_deref(), None, None, &mut out, None).unwrap();
+        assert_eq!(format_header(&header), "team TEXT | SUM(score) INTEGER");
+        out.sort();
+        assert_eq!(out.len(), 2);
+    } else { panic!("expected select") }
+}
+
+#[test]
+fn all_aggregated_ok() {
+    let filename = "test_group_all_agg.db";
+    let mut catalog = setup_catalog(filename);
+    create_matches_table(&mut catalog);
+    let stmt = parse_statement("SELECT SUM(score) FROM matches GROUP BY team").unwrap();
+    if let Statement::Select { columns, from, group_by, .. } = stmt {
+        let table = match from.first().unwrap() { aerodb::sql::ast::TableRef::Named { name, .. } => name, _ => panic!("expected table") };
+        let mut out = Vec::new();
+        let header = execute_group_query(&mut catalog, table, &columns, group_by.as_deref(), None, None, &mut out, None).unwrap();
+        assert_eq!(format_header(&header), "SUM(score) INTEGER");
+    } else { panic!("expected select") }
+}
+
+#[test]
+fn having_uses_aggregate() {
+    let filename = "test_group_having.db";
+    let mut catalog = setup_catalog(filename);
+    create_matches_table(&mut catalog);
+    let stmt = parse_statement("SELECT team, COUNT(*) FROM matches GROUP BY team HAVING COUNT(*) > 1").unwrap();
+    if let Statement::Select { columns, from, group_by, having: Some(have), .. } = stmt {
+        let table = match from.first().unwrap() { aerodb::sql::ast::TableRef::Named { name, .. } => name, _ => panic!("expected table") };
+        let mut out = Vec::new();
+        let header = execute_group_query(&mut catalog, table, &columns, group_by.as_deref(), Some(have), None, &mut out, None).unwrap();
+        assert_eq!(format_header(&header), "team TEXT | COUNT(*) INTEGER");
+        assert_eq!(out.len(), 1);
+    } else { panic!("expected select") }
+}
+
+#[test]
+fn reject_non_grouped_select() {
+    let filename = "test_group_fail1.db";
+    let mut catalog = setup_catalog(filename);
+    create_matches_table(&mut catalog);
+    let stmt = parse_statement("SELECT id, SUM(score) FROM matches GROUP BY team").unwrap();
+    let res = aerodb::execution::handle_statement(&mut catalog, stmt);
+    assert!(matches!(res, Err(aerodb::error::DbError::GroupByMismatch(_))));
+}
+
+#[test]
+fn reject_missing_group_column() {
+    let filename = "test_group_fail2.db";
+    let mut catalog = setup_catalog(filename);
+    create_matches_table(&mut catalog);
+    let stmt = parse_statement("SELECT id FROM matches GROUP BY team").unwrap();
+    let res = aerodb::execution::handle_statement(&mut catalog, stmt);
+    assert!(matches!(res, Err(aerodb::error::DbError::GroupByMismatch(_))));
+}
+
+#[test]
+fn reject_extra_group_column() {
+    let filename = "test_group_fail3.db";
+    let mut catalog = setup_catalog(filename);
+    create_matches_table(&mut catalog);
+    let stmt = parse_statement("SELECT team FROM matches GROUP BY team, league").unwrap();
+    let res = aerodb::execution::handle_statement(&mut catalog, stmt);
+    assert!(matches!(res, Err(aerodb::error::DbError::GroupByMismatch(_))));
+}
+


### PR DESCRIPTION
## Summary
- add GROUP BY validation into planner
- surface new `GroupByMismatch` error
- update runtime to validate grouped queries
- document GROUP BY behavior
- add integration tests for GROUP BY rules

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685ab44cf13c83339ecd32e8cf9a9425