### PR TITLE
Add implicit transaction engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ DROP TABLE users;
 
 `DROP INDEX` removes the specified index from the catalog so new queries fall back to full table scans when appropriate.
 
+## Transactions
+
+By default every statement is executed in its own transaction unless you wrap multiple statements in an explicit `BEGIN ... COMMIT` block.
+
 ## Project Structure
 
 - `src/` – Rust source code for the database engine.

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -195,6 +195,10 @@ impl Catalog {
         self.reload_tables()
     }
 
+    pub fn transaction_active(&self) -> bool {
+        self.pager.transaction_active()
+    }
+
     /// Create a new table with `name` and `columns`. Allocates a fresh page for the table’s root,
     /// then inserts one catalog row into page 1 (the catalog B-Tree), and updates `tables`.
     pub fn create_table(&mut self, name: &str, columns: Vec<(String, ColumnType)>) -> io::Result<()> {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,0 +1,78 @@
+use crate::{catalog::Catalog, storage::pager::Pager, sql::ast::Statement, execution::runtime::handle_statement, error::DbResult};
+
+#[derive(PartialEq)]
+enum TransactionMode {
+    None,
+    Implicit,
+    Explicit,
+}
+
+pub struct Engine {
+    pub catalog: Catalog,
+    tx_mode: TransactionMode,
+}
+
+impl Engine {
+    pub fn new(filename: &str) -> Self {
+        let catalog = Catalog::open(Pager::new(filename).unwrap()).unwrap();
+        Engine { catalog, tx_mode: TransactionMode::None }
+    }
+
+    pub fn execute(&mut self, stmt: Statement) -> DbResult<()> {
+        use Statement::*;
+
+        match &stmt {
+            BeginTransaction { name } => {
+                if self.tx_mode == TransactionMode::Implicit && self.catalog.transaction_active() {
+                    self.catalog.commit_transaction()?;
+                }
+                self.catalog.begin_transaction(name.clone())?;
+                self.tx_mode = TransactionMode::Explicit;
+                return Ok(());
+            }
+            Commit => {
+                self.catalog.commit_transaction()?;
+                self.tx_mode = TransactionMode::None;
+                return Ok(());
+            }
+            Rollback => {
+                self.catalog.rollback_transaction()?;
+                self.tx_mode = TransactionMode::None;
+                return Ok(());
+            }
+            _ => {}
+        }
+
+        let mut implicit = false;
+        let is_mutating = matches!(
+            stmt,
+            Insert { .. }
+                | Update { .. }
+                | Delete { .. }
+                | CreateTable { .. }
+                | DropTable { .. }
+                | CreateIndex { .. }
+                | DropIndex { .. }
+                | CreateSequence(_)
+        );
+
+        if is_mutating && !self.catalog.transaction_active() {
+            self.catalog.begin_transaction(None)?;
+            self.tx_mode = TransactionMode::Implicit;
+            implicit = true;
+        }
+
+        let res = handle_statement(&mut self.catalog, stmt);
+
+        if implicit {
+            if res.is_ok() {
+                self.catalog.commit_transaction()?;
+            } else {
+                self.catalog.rollback_transaction()?;
+            }
+            self.tx_mode = TransactionMode::None;
+        }
+
+        res
+    }
+}

--- a/src/execution/runtime.rs
+++ b/src/execution/runtime.rs
@@ -254,7 +254,6 @@ pub fn execute_insert(
     let columns_meta = table_info.columns.clone();
     let fks = table_info.fks.clone();
 
-    catalog.begin_transaction(None)?;
     let mut inserted = 0usize;
     let mut result: DbResult<()> = Ok(());
 
@@ -392,12 +391,9 @@ pub fn execute_insert(
     }
 
     if result.is_ok() {
-        catalog.commit_transaction()?;
         Ok(inserted)
     } else {
-        let err = result.unwrap_err();
-        catalog.rollback_transaction()?;
-        Err(err)
+        Err(result.unwrap_err())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod engine;
 pub mod storage;
 pub mod sql;
 pub mod catalog;

--- a/src/storage/pager.rs
+++ b/src/storage/pager.rs
@@ -146,6 +146,10 @@ impl Pager {
         self.num_pages
     }
 
+    pub fn transaction_active(&self) -> bool {
+        self.transaction_active
+    }
+
     pub fn begin_transaction(&mut self, _name: Option<String>) -> io::Result<()> {
         self.transaction_active = true;
         self.dirty_pages.clear();

--- a/tests/auto_commit.rs
+++ b/tests/auto_commit.rs
@@ -1,0 +1,64 @@
+use aerodb::{engine::Engine, sql::parser::parse_statement, execution::runtime::execute_select_with_indexes};
+use std::fs;
+
+fn setup_engine(filename: &str) -> Engine {
+    let _ = fs::remove_file(filename);
+    let _ = fs::remove_file(format!("{}.wal", filename));
+    Engine::new(filename)
+}
+
+fn open_engine(filename: &str) -> Engine {
+    Engine::new(filename)
+}
+
+#[test]
+fn insert_auto_commit_ok() {
+    let filename = "auto_commit_ok.db";
+    let mut engine = setup_engine(filename);
+    engine.execute(parse_statement("CREATE TABLE t (id INTEGER PRIMARY KEY)").unwrap()).unwrap();
+    engine.execute(parse_statement("INSERT INTO t VALUES (1)").unwrap()).unwrap();
+    drop(engine);
+
+    let mut engine2 = open_engine(filename);
+    let mut rows = Vec::new();
+    execute_select_with_indexes(&mut engine2.catalog, "t", None, &mut rows).unwrap();
+    assert_eq!(rows.len(), 1);
+}
+
+#[test]
+fn insert_auto_commit_err() {
+    let filename = "auto_commit_err.db";
+    let mut engine = setup_engine(filename);
+    engine.execute(parse_statement("CREATE TABLE t (id INTEGER PRIMARY KEY)").unwrap()).unwrap();
+    engine.execute(parse_statement("INSERT INTO t VALUES (1)").unwrap()).unwrap();
+    let res = engine.execute(parse_statement("INSERT INTO t VALUES (1)").unwrap());
+    assert!(res.is_err());
+    drop(engine);
+
+    let mut engine2 = open_engine(filename);
+    let mut rows = Vec::new();
+    execute_select_with_indexes(&mut engine2.catalog, "t", None, &mut rows).unwrap();
+    assert_eq!(rows.len(), 1);
+}
+
+#[test]
+fn begin_explicit_preserves_manual_flow() {
+    let filename = "explicit_tx.db";
+    let mut engine = setup_engine(filename);
+    engine.execute(parse_statement("CREATE TABLE t (id INTEGER PRIMARY KEY)").unwrap()).unwrap();
+    engine.execute(parse_statement("BEGIN").unwrap()).unwrap();
+    engine.execute(parse_statement("INSERT INTO t VALUES (1)").unwrap()).unwrap();
+
+    // changes should not be visible before commit
+    let mut other = open_engine(filename);
+    let mut rows = Vec::new();
+    execute_select_with_indexes(&mut other.catalog, "t", None, &mut rows).unwrap();
+    assert!(rows.is_empty());
+
+    engine.execute(parse_statement("COMMIT").unwrap()).unwrap();
+    drop(other);
+    let mut check = open_engine(filename);
+    let mut rows2 = Vec::new();
+    execute_select_with_indexes(&mut check.catalog, "t", None, &mut rows2).unwrap();
+    assert_eq!(rows2.len(), 1);
+}

--- a/tests/insert.rs
+++ b/tests/insert.rs
@@ -3,6 +3,7 @@ use aerodb::{
     storage::pager::Pager,
     sql::{parser::parse_statement, ast::Statement},
     execution::runtime::{handle_statement, execute_select_with_indexes},
+    engine::Engine,
 };
 use std::fs;
 
@@ -29,16 +30,17 @@ fn multi_value_insert_happy_path() {
 #[test]
 fn multi_value_insert_rollback_on_error() {
     let filename = "multi_insert_rollback.db";
-    let mut catalog = setup_catalog(filename);
-    let create = parse_statement("CREATE TABLE nums (n INTEGER PRIMARY KEY)").unwrap();
-    if let Statement::CreateTable { table_name, columns, fks, primary_key, if_not_exists } = create {
-        handle_statement(&mut catalog, Statement::CreateTable { table_name, columns, fks, primary_key, if_not_exists }).unwrap();
-    }
-    handle_statement(&mut catalog, parse_statement("INSERT INTO nums VALUES (1), (2), (3)").unwrap()).unwrap();
-    let res = handle_statement(&mut catalog, parse_statement("INSERT INTO nums VALUES (4), (4), (5)").unwrap());
+    let _ = fs::remove_file(filename);
+    let _ = fs::remove_file(format!("{}.wal", filename));
+    let mut engine = Engine::new(filename);
+    engine.execute(parse_statement("CREATE TABLE nums (n INTEGER PRIMARY KEY)").unwrap()).unwrap();
+    engine.execute(parse_statement("INSERT INTO nums VALUES (1), (2), (3)").unwrap()).unwrap();
+    let res = engine.execute(parse_statement("INSERT INTO nums VALUES (4), (4), (5)").unwrap());
     assert!(res.is_err());
+    drop(engine);
+    let mut engine = Engine::new(filename);
     let mut rows = Vec::new();
-    execute_select_with_indexes(&mut catalog, "nums", None, &mut rows).unwrap();
+    execute_select_with_indexes(&mut engine.catalog, "nums", None, &mut rows).unwrap();
     assert_eq!(rows.len(), 3);
 }
 


### PR DESCRIPTION
## Summary
- implement new `Engine` with implicit and explicit transactions
- expose transaction state via `Catalog` and `Pager`
- remove transaction logic from `execute_insert`
- update README with basic transaction documentation
- add integration tests for auto commit and update existing insert test

## Testing
- `cargo test --test auto_commit -- --test-threads=1`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685ab8d9ad8883339267c67370c6aaaa