### PR TITLE
Add tests for SELECT ORDER BY/LIMIT/OFFSET parsing

### DIFF
--- a/src/execution/plan.rs
+++ b/src/execution/plan.rs
@@ -70,7 +70,7 @@ pub fn plan_statement(stmt: Statement) -> PlanNode {
                 PlanNode::Insert { table_name, values: Vec::new() }
             }
         }
-        Statement::Select { columns, from, joins, where_predicate, group_by: _, having: _ } => {
+        Statement::Select { columns, from, joins, where_predicate, order_by, limit, offset, group_by: _, having: _ } => {
             let (table_name, base_alias) = match from.first().unwrap() {
                 crate::sql::ast::TableRef::Named { name, alias } => (name.clone(), alias.clone()),
                 _ => return PlanNode::Select { table_name: String::new(), selection: None, limit: None, offset: None, order_by: None },
@@ -79,9 +79,9 @@ pub fn plan_statement(stmt: Statement) -> PlanNode {
                 PlanNode::Select {
                     table_name,
                     selection: where_predicate,
-                    limit: None,
-                    offset: None,
-                    order_by: None,
+                    limit,
+                    offset,
+                    order_by,
                 }
             } else {
                 PlanNode::MultiJoin(MultiJoinPlan {

--- a/src/execution/runtime.rs
+++ b/src/execution/runtime.rs
@@ -799,7 +799,7 @@ pub fn handle_statement(catalog: &mut Catalog, stmt: Statement) -> DbResult<()> 
         Statement::Insert { table_name, columns: col_list, rows } => {
             execute_insert(catalog, &table_name, col_list, rows)?;
         }
-        Statement::Select { columns, from, joins, where_predicate, group_by, having } => {
+        Statement::Select { columns, from, joins, where_predicate, group_by, having, order_by, limit, offset } => {
             let has_subquery = from.iter().any(|t| matches!(t, crate::sql::ast::TableRef::Subquery { .. }))
                 || columns.iter().any(|c| matches!(c.expr, crate::sql::ast::SelectItem::Subquery(_)))
                 || where_predicate.as_ref().map_or(false, |e| expr_has_subquery(e));
@@ -811,6 +811,9 @@ pub fn handle_statement(catalog: &mut Catalog, stmt: Statement) -> DbResult<()> 
                     where_predicate: where_predicate.clone(),
                     group_by: group_by.clone(),
                     having: having.clone(),
+                    order_by: order_by.clone(),
+                    limit,
+                    offset,
                 };
                 let mut results = Vec::new();
                 let header = execute_select_statement(catalog, &stmt, &mut results, None)?;
@@ -828,6 +831,9 @@ pub fn handle_statement(catalog: &mut Catalog, stmt: Statement) -> DbResult<()> 
                     where_predicate: None,
                     group_by: None,
                     having: None,
+                    order_by: order_by.clone(),
+                    limit,
+                    offset,
                 };
                 let mut results = Vec::new();
                 let header = execute_select_statement(catalog, &stmt, &mut results, None)?;
@@ -1182,9 +1188,16 @@ pub fn execute_select_statement(
     use crate::sql::ast::{SelectExpr, SelectItem, TableRef};
     use crate::storage::row::ColumnType;
     match stmt {
-        crate::sql::ast::Statement::Select { columns, from, joins, where_predicate, group_by, having } => {
+        crate::sql::ast::Statement::Select { columns, from, joins, where_predicate, group_by, having, order_by, limit, offset } => {
             if from.is_empty() {
-                if !joins.is_empty() || where_predicate.is_some() || group_by.is_some() || having.is_some() {
+                if !joins.is_empty()
+                    || where_predicate.is_some()
+                    || group_by.is_some()
+                    || having.is_some()
+                    || order_by.is_some()
+                    || limit.is_some()
+                    || offset.is_some()
+                {
                     return Err(DbError::InvalidValue("Unsupported query".into()));
                 }
                 let mut row = Vec::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -411,12 +411,17 @@ mod tests {
     #[test]
     fn parse_select_limit_offset_order() {
         let stmt =
-            parse_statement("SELECT * FROM nums LIMIT 5 OFFSET 2 ORDER BY id DESC").unwrap();
+            parse_statement("SELECT * FROM nums ORDER BY id DESC LIMIT 5 OFFSET 2").unwrap();
         match stmt {
-            Statement::Select { from, .. } => {
+            Statement::Select { from, order_by, limit, offset, .. } => {
                 if let Some(crate::sql::ast::TableRef::Named { name, .. }) = from.first() {
                     assert_eq!(name, "nums");
                 } else { panic!("expected named table") }
+                assert_eq!(limit, Some(5));
+                assert_eq!(offset, Some(2));
+                let order_by = order_by.expect("expected order by");
+                assert_eq!(order_by.column, "id");
+                assert!(order_by.descending);
             }
             _ => panic!("Expected select statement"),
         }
@@ -426,30 +431,55 @@ mod tests {
     fn parse_order_by_variants() {
         let stmt = parse_statement("SELECT * FROM users ORDER BY id").unwrap();
         match stmt {
-            Statement::Select { from, .. } => {
+            Statement::Select { from, order_by, .. } => {
                 if let Some(crate::sql::ast::TableRef::Named { name, .. }) = from.first() {
                     assert_eq!(name, "users");
                 } else { panic!("expected named table") }
+                let order_by = order_by.expect("expected order by");
+                assert_eq!(order_by.column, "id");
+                assert!(!order_by.descending);
             }
             _ => panic!("Expected select"),
         }
 
         let stmt = parse_statement("SELECT * FROM users ORDER BY id ASC").unwrap();
         match stmt {
-            Statement::Select { from, .. } => {
+            Statement::Select { from, order_by, .. } => {
                 if let Some(crate::sql::ast::TableRef::Named { name, .. }) = from.first() {
                     assert_eq!(name, "users");
                 } else { panic!("expected named table") }
+                let order_by = order_by.expect("expected order by");
+                assert_eq!(order_by.column, "id");
+                assert!(!order_by.descending);
             }
             _ => panic!("Expected select"),
         }
 
         let stmt = parse_statement("SELECT * FROM users ORDER BY id DESC").unwrap();
         match stmt {
-            Statement::Select { from, .. } => {
+            Statement::Select { from, order_by, .. } => {
                 if let Some(crate::sql::ast::TableRef::Named { name, .. }) = from.first() {
                     assert_eq!(name, "users");
                 } else { panic!("expected named table") }
+                let order_by = order_by.expect("expected order by");
+                assert_eq!(order_by.column, "id");
+                assert!(order_by.descending);
+            }
+            _ => panic!("Expected select"),
+        }
+    }
+
+    #[test]
+    fn parse_limit_offset_without_order() {
+        let stmt = parse_statement("SELECT * FROM users LIMIT 3 OFFSET 1").unwrap();
+        match stmt {
+            Statement::Select { from, order_by, limit, offset, .. } => {
+                if let Some(crate::sql::ast::TableRef::Named { name, .. }) = from.first() {
+                    assert_eq!(name, "users");
+                } else { panic!("expected named table") }
+                assert!(order_by.is_none());
+                assert_eq!(limit, Some(3));
+                assert_eq!(offset, Some(1));
             }
             _ => panic!("Expected select"),
         }

--- a/src/sql/ast.rs
+++ b/src/sql/ast.rs
@@ -28,7 +28,7 @@ pub enum Expr {
     FunctionCall { name: String, args: Vec<Expr> },
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct OrderBy {
     pub column: String,
     pub descending: bool,
@@ -155,6 +155,9 @@ pub enum Statement {
         where_predicate: Option<Predicate>,
         group_by: Option<Vec<String>>,
         having: Option<Predicate>,
+        order_by: Option<OrderBy>,
+        limit: Option<usize>,
+        offset: Option<usize>,
     },
     Delete {
         table_name: String,

--- a/src/sql/parser.rs
+++ b/src/sql/parser.rs
@@ -560,7 +560,17 @@ pub fn parse_statement(input: &str) -> Result<Statement, String> {
                 if columns.iter().any(|c| matches!(c.expr, crate::sql::ast::SelectItem::Column(_) | crate::sql::ast::SelectItem::All | crate::sql::ast::SelectItem::Aggregate { .. })) {
                     return Err("Column without table".into());
                 }
-                return Ok(Statement::Select { columns, from: Vec::new(), joins: Vec::new(), where_predicate: None, group_by: None, having: None });
+                return Ok(Statement::Select {
+                    columns,
+                    from: Vec::new(),
+                    joins: Vec::new(),
+                    where_predicate: None,
+                    group_by: None,
+                    having: None,
+                    order_by: None,
+                    limit: None,
+                    offset: None,
+                });
             }
             if !tokens[idx].eq_ignore_ascii_case("FROM") {
                 return Err("Expected FROM".into());
@@ -691,7 +701,70 @@ pub fn parse_statement(input: &str) -> Result<Statement, String> {
                 idx += consumed + 1;
             }
 
-            Ok(Statement::Select { columns, from, joins, where_predicate, group_by, having })
+            let mut order_by = None;
+            if idx + 1 < tokens.len()
+                && tokens[idx].eq_ignore_ascii_case("ORDER")
+                && tokens[idx + 1].eq_ignore_ascii_case("BY")
+            {
+                idx += 2;
+                if idx >= tokens.len() {
+                    return Err("Expected column after ORDER BY".into());
+                }
+                let column = tokens[idx].trim_end_matches(',').trim_end_matches(';');
+                if tokens[idx].ends_with(',') {
+                    return Err("Only one ORDER BY column is supported".into());
+                }
+                let mut descending = false;
+                idx += 1;
+                if idx < tokens.len() {
+                    let keyword = tokens[idx].trim_end_matches(';');
+                    if keyword.eq_ignore_ascii_case("DESC") {
+                        descending = true;
+                        idx += 1;
+                    } else if keyword.eq_ignore_ascii_case("ASC") {
+                        idx += 1;
+                    }
+                }
+                if idx < tokens.len() {
+                    let keyword = tokens[idx].trim_end_matches(';');
+                    if !keyword.eq_ignore_ascii_case("LIMIT") && !keyword.eq_ignore_ascii_case("OFFSET") {
+                        return Err("Unexpected token after ORDER BY clause".into());
+                    }
+                }
+                if column.is_empty() {
+                    return Err("Expected column after ORDER BY".into());
+                }
+                if column.contains(',') {
+                    return Err("Unexpected token after ORDER BY clause".into());
+                }
+                order_by = Some(OrderBy { column: column.to_string(), descending });
+            }
+
+            let mut limit = None;
+            if idx < tokens.len() && tokens[idx].trim_end_matches(';').eq_ignore_ascii_case("LIMIT") {
+                idx += 1;
+                if idx >= tokens.len() {
+                    return Err("Expected value after LIMIT".into());
+                }
+                let raw = tokens[idx].trim_end_matches(';');
+                let value = raw.parse::<usize>().map_err(|_| "Invalid LIMIT value".to_string())?;
+                limit = Some(value);
+                idx += 1;
+            }
+
+            let mut offset = None;
+            if idx < tokens.len() && tokens[idx].trim_end_matches(';').eq_ignore_ascii_case("OFFSET") {
+                idx += 1;
+                if idx >= tokens.len() {
+                    return Err("Expected value after OFFSET".into());
+                }
+                let raw = tokens[idx].trim_end_matches(';');
+                let value = raw.parse::<usize>().map_err(|_| "Invalid OFFSET value".to_string())?;
+                offset = Some(value);
+                idx += 1;
+            }
+
+            Ok(Statement::Select { columns, from, joins, where_predicate, group_by, having, order_by, limit, offset })
         }
         "DROP" => {
             if tokens.len() < 3 {


### PR DESCRIPTION
### Motivation
- Ensure the SQL parser and planner preserve `ORDER BY`, `LIMIT`, and `OFFSET` clauses and to add regression coverage for clause ordering and variants.
- Verify the parser accepts `ORDER BY <col> [ASC|DESC]`, `LIMIT <n>`, and `OFFSET <n>` in common positions and that these parsed values are visible in the AST/plan/runtime.

### Description
- Added unit tests in `src/main.rs` (`parse_select_limit_offset_order`, `parse_order_by_variants`, `parse_limit_offset_without_order`) that assert parsed `order_by`, `limit`, and `offset` values and clause ordering using `parse_statement` and pattern-matching on `Statement::Select`.
- Exposed `order_by: Option<OrderBy>`, `limit: Option<usize>`, and `offset: Option<usize>` on `Statement::Select` and made `OrderBy` `Clone` in `src/sql/ast.rs` to allow downstream use.
- Extended the parser in `src/sql/parser.rs` to recognize and validate `ORDER BY`, `LIMIT`, and `OFFSET` clauses, including simple token sequencing and basic error messages for malformed inputs.
- Threaded the parsed fields through planning and execution by updating `plan_statement` in `src/execution/plan.rs` and statement handling in `src/execution/runtime.rs` so that `PlanNode::Select` and runtime paths preserve the metadata and reject unsupported combinations when `from` is empty.

### Testing
- Ran `cargo test` which executed the test suite including the new parsing tests and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971218e48888333b98e2dc4e644db4c)