### PR TITLE
Extract transaction logic to TransactionManager; add pager transaction state and DirtyPageSet

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,78 +1,24 @@
-use crate::{catalog::Catalog, storage::pager::Pager, sql::ast::Statement, execution::runtime::handle_statement, error::DbResult};
-
-#[derive(PartialEq)]
-enum TransactionMode {
-    None,
-    Implicit,
-    Explicit,
-}
+use crate::{
+    catalog::Catalog, error::DbResult, execution::runtime::handle_statement, sql::ast::Statement,
+    storage::pager::Pager, transaction::TransactionManager,
+};
 
 pub struct Engine {
     pub catalog: Catalog,
-    tx_mode: TransactionMode,
+    transaction_manager: TransactionManager,
 }
 
 impl Engine {
     pub fn new(filename: &str) -> Self {
         let catalog = Catalog::open(Pager::new(filename).unwrap()).unwrap();
-        Engine { catalog, tx_mode: TransactionMode::None }
+        Engine {
+            catalog,
+            transaction_manager: TransactionManager::new(),
+        }
     }
 
     pub fn execute(&mut self, stmt: Statement) -> DbResult<()> {
-        use Statement::*;
-
-        match &stmt {
-            BeginTransaction { name } => {
-                if self.tx_mode == TransactionMode::Implicit && self.catalog.transaction_active() {
-                    self.catalog.commit_transaction()?;
-                }
-                self.catalog.begin_transaction(name.clone())?;
-                self.tx_mode = TransactionMode::Explicit;
-                return Ok(());
-            }
-            Commit => {
-                self.catalog.commit_transaction()?;
-                self.tx_mode = TransactionMode::None;
-                return Ok(());
-            }
-            Rollback => {
-                self.catalog.rollback_transaction()?;
-                self.tx_mode = TransactionMode::None;
-                return Ok(());
-            }
-            _ => {}
-        }
-
-        let mut implicit = false;
-        let is_mutating = matches!(
-            stmt,
-            Insert { .. }
-                | Update { .. }
-                | Delete { .. }
-                | CreateTable { .. }
-                | DropTable { .. }
-                | CreateIndex { .. }
-                | DropIndex { .. }
-                | CreateSequence(_)
-        );
-
-        if is_mutating && !self.catalog.transaction_active() {
-            self.catalog.begin_transaction(None)?;
-            self.tx_mode = TransactionMode::Implicit;
-            implicit = true;
-        }
-
-        let res = handle_statement(&mut self.catalog, stmt);
-
-        if implicit {
-            if res.is_ok() {
-                self.catalog.commit_transaction()?;
-            } else {
-                self.catalog.rollback_transaction()?;
-            }
-            self.tx_mode = TransactionMode::None;
-        }
-
-        res
+        self.transaction_manager
+            .execute(&mut self.catalog, stmt, handle_statement)
     }
 }

--- a/src/storage/dirty_pages.rs
+++ b/src/storage/dirty_pages.rs
@@ -1,0 +1,28 @@
+use crate::storage::page::PAGE_SIZE;
+use std::collections::HashMap;
+
+#[derive(Debug, Default)]
+pub(super) struct DirtyPageSet {
+    pages: HashMap<u32, [u8; PAGE_SIZE]>,
+}
+
+impl DirtyPageSet {
+    pub(super) fn mark(&mut self, page_num: u32, data: [u8; PAGE_SIZE]) {
+        self.pages.insert(page_num, data);
+    }
+
+    pub(super) fn snapshot(&self) -> Vec<(u32, [u8; PAGE_SIZE])> {
+        self.pages
+            .iter()
+            .map(|(page_num, data)| (*page_num, *data))
+            .collect()
+    }
+
+    pub(super) fn page_numbers(&self) -> Vec<u32> {
+        self.pages.keys().copied().collect()
+    }
+
+    pub(super) fn clear(&mut self) {
+        self.pages.clear();
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,4 +1,5 @@
-pub mod pager;
-pub mod page;
 pub mod btree;
+mod dirty_pages;
+pub mod page;
+pub mod pager;
 pub mod row;

--- a/src/storage/pager.rs
+++ b/src/storage/pager.rs
@@ -1,8 +1,7 @@
-use std::collections::HashMap;
-use std::fs::{OpenOptions, File};
-use std::io::{self, Read, Write, Seek, SeekFrom};
-use crate::transaction::wal::Wal;
-use crate::storage::page::PAGE_SIZE;
+use crate::storage::{dirty_pages::DirtyPageSet, page::PAGE_SIZE};
+use crate::transaction::{wal::Wal, TransactionState};
+use std::fs::{File, OpenOptions};
+use std::io::{self, Read, Seek, SeekFrom, Write};
 
 /// A single 4 KiB page of data.
 pub struct Page {
@@ -11,7 +10,9 @@ pub struct Page {
 
 impl Page {
     pub fn new() -> Self {
-        Page { data: [0; PAGE_SIZE] }
+        Page {
+            data: [0; PAGE_SIZE],
+        }
     }
 }
 
@@ -32,8 +33,8 @@ pub struct Pager {
     /// A very basic cache: `cache[page_num] = Some(Box<Page>)` if that page is loaded.
     cache: Vec<Option<Box<Page>>>,
 
-    transaction_active: bool,
-    dirty_pages: HashMap<u32, [u8; PAGE_SIZE]>,
+    transaction: TransactionState,
+    dirty_pages: DirtyPageSet,
 }
 
 impl Pager {
@@ -59,8 +60,8 @@ impl Pager {
             file_length_pages,
             num_pages: file_length_pages,
             cache: Vec::new(),
-            transaction_active: false,
-            dirty_pages: HashMap::new(),
+            transaction: TransactionState::default(),
+            dirty_pages: DirtyPageSet::default(),
         })
     }
 
@@ -115,8 +116,8 @@ impl Pager {
     pub fn flush_page(&mut self, page_num: u32) -> io::Result<()> {
         if let Some(page_box) = &self.cache[page_num as usize] {
             let data = page_box.data;
-            if self.transaction_active {
-                self.dirty_pages.insert(page_num, data);
+            if self.transaction.is_active() {
+                self.dirty_pages.mark(page_num, data);
             } else {
                 self.wal.append_page(page_num, &data)?;
                 self.write_page_raw(page_num, &data)?;
@@ -147,19 +148,18 @@ impl Pager {
     }
 
     pub fn transaction_active(&self) -> bool {
-        self.transaction_active
+        self.transaction.is_active()
     }
 
-    pub fn begin_transaction(&mut self, _name: Option<String>) -> io::Result<()> {
-        self.transaction_active = true;
+    pub fn begin_transaction(&mut self, name: Option<String>) -> io::Result<()> {
+        self.transaction.begin(name);
         self.dirty_pages.clear();
         Ok(())
     }
 
     pub fn commit_transaction(&mut self) -> io::Result<()> {
-        if self.transaction_active {
-            let pages = self.dirty_pages.clone();
-            for (page_num, data) in pages {
+        if self.transaction.is_active() {
+            for (page_num, data) in self.dirty_pages.snapshot() {
                 self.wal.append_page(page_num, &data)?;
                 self.write_page_raw(page_num, &data)?;
             }
@@ -167,14 +167,14 @@ impl Pager {
             self.wal.truncate()?;
             self.file.sync_all()?;
             self.dirty_pages.clear();
-            self.transaction_active = false;
+            self.transaction.finish();
         }
         Ok(())
     }
 
     pub fn rollback_transaction(&mut self) -> io::Result<()> {
-        if self.transaction_active {
-            for page_num in self.dirty_pages.keys().cloned().collect::<Vec<_>>() {
+        if self.transaction.is_active() {
+            for page_num in self.dirty_pages.page_numbers() {
                 let mut buf = [0u8; PAGE_SIZE];
                 if page_num < self.file_length_pages {
                     let offset = (page_num as u64) * (PAGE_SIZE as u64);
@@ -187,12 +187,11 @@ impl Pager {
             }
             self.wal.truncate()?;
             self.dirty_pages.clear();
-            self.transaction_active = false;
+            self.transaction.finish();
         }
         Ok(())
     }
 }
-
 
 // #[test]
 // fn test_leaf_multiple_inserts_and_find() {

--- a/src/transaction/classifier.rs
+++ b/src/transaction/classifier.rs
@@ -1,0 +1,32 @@
+use crate::sql::ast::Statement;
+
+/// Returns true for statements that change persistent database state and should
+/// therefore be wrapped in an implicit transaction when no explicit one exists.
+pub fn statement_requires_transaction(stmt: &Statement) -> bool {
+    matches!(
+        stmt,
+        Statement::Insert { .. }
+            | Statement::Update { .. }
+            | Statement::Delete { .. }
+            | Statement::CreateTable { .. }
+            | Statement::DropTable { .. }
+            | Statement::CreateIndex { .. }
+            | Statement::DropIndex { .. }
+            | Statement::CreateSequence(_)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sql::parser::parse_statement;
+
+    #[test]
+    fn identifies_mutating_statements() {
+        let insert = parse_statement("INSERT INTO users VALUES (1)").unwrap();
+        let select = parse_statement("SELECT * FROM users").unwrap();
+
+        assert!(statement_requires_transaction(&insert));
+        assert!(!statement_requires_transaction(&select));
+    }
+}

--- a/src/transaction/manager.rs
+++ b/src/transaction/manager.rs
@@ -1,0 +1,96 @@
+use crate::{catalog::Catalog, error::DbResult, sql::ast::Statement};
+use std::io;
+
+use super::{statement_requires_transaction, TransactionMode};
+
+/// Coordinates SQL transaction boundaries for the engine while keeping statement
+/// execution itself outside the transaction module.
+#[derive(Debug, Default)]
+pub struct TransactionManager {
+    mode: TransactionMode,
+}
+
+impl TransactionManager {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn execute<F>(
+        &mut self,
+        catalog: &mut Catalog,
+        stmt: Statement,
+        execute_stmt: F,
+    ) -> DbResult<()>
+    where
+        F: FnOnce(&mut Catalog, Statement) -> DbResult<()>,
+    {
+        if self.handle_transaction_control(catalog, &stmt)? {
+            return Ok(());
+        }
+
+        let implicit = self.begin_implicit_if_needed(catalog, &stmt)?;
+        let result = execute_stmt(catalog, stmt);
+        self.finish_implicit_if_needed(catalog, implicit, result)
+    }
+
+    fn handle_transaction_control(
+        &mut self,
+        catalog: &mut Catalog,
+        stmt: &Statement,
+    ) -> io::Result<bool> {
+        match stmt {
+            Statement::BeginTransaction { name } => {
+                if self.mode.is_implicit() && catalog.transaction_active() {
+                    catalog.commit_transaction()?;
+                }
+                catalog.begin_transaction(name.clone())?;
+                self.mode = TransactionMode::Explicit;
+                Ok(true)
+            }
+            Statement::Commit => {
+                catalog.commit_transaction()?;
+                self.mode = TransactionMode::None;
+                Ok(true)
+            }
+            Statement::Rollback => {
+                catalog.rollback_transaction()?;
+                self.mode = TransactionMode::None;
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    fn begin_implicit_if_needed(
+        &mut self,
+        catalog: &mut Catalog,
+        stmt: &Statement,
+    ) -> io::Result<bool> {
+        if statement_requires_transaction(stmt) && !catalog.transaction_active() {
+            catalog.begin_transaction(None)?;
+            self.mode = TransactionMode::Implicit;
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
+
+    fn finish_implicit_if_needed(
+        &mut self,
+        catalog: &mut Catalog,
+        implicit: bool,
+        result: DbResult<()>,
+    ) -> DbResult<()> {
+        if !implicit {
+            return result;
+        }
+
+        if result.is_ok() {
+            catalog.commit_transaction()?;
+        } else {
+            catalog.rollback_transaction()?;
+        }
+        self.mode = TransactionMode::None;
+        result
+    }
+}

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -1,3 +1,9 @@
 pub mod wal;
 
-// For now, empty. Later, put Transaction struct here.
+mod classifier;
+mod manager;
+mod state;
+
+pub use classifier::statement_requires_transaction;
+pub use manager::TransactionManager;
+pub use state::{TransactionMode, TransactionState};

--- a/src/transaction/state.rs
+++ b/src/transaction/state.rs
@@ -1,0 +1,68 @@
+/// Tracks whether the engine is currently outside a transaction, running an
+/// auto-commit transaction, or inside a user-managed transaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransactionMode {
+    None,
+    Implicit,
+    Explicit,
+}
+
+impl TransactionMode {
+    pub fn is_implicit(self) -> bool {
+        matches!(self, TransactionMode::Implicit)
+    }
+}
+
+impl Default for TransactionMode {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+/// Pager-level transaction bookkeeping. Keeping this state behind a single type
+/// gives future MVCC work one place to add transaction ids, snapshots, and page
+/// version metadata without spreading those fields through the pager.
+#[derive(Debug, Default)]
+pub struct TransactionState {
+    active: bool,
+    name: Option<String>,
+}
+
+impl TransactionState {
+    pub fn is_active(&self) -> bool {
+        self.active
+    }
+
+    pub fn begin(&mut self, name: Option<String>) {
+        self.active = true;
+        self.name = name;
+    }
+
+    pub fn finish(&mut self) {
+        self.active = false;
+        self.name = None;
+    }
+
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transaction_state_tracks_lifecycle() {
+        let mut state = TransactionState::default();
+        assert!(!state.is_active());
+
+        state.begin(Some("tx".to_string()));
+        assert!(state.is_active());
+        assert_eq!(state.name(), Some("tx"));
+
+        state.finish();
+        assert!(!state.is_active());
+        assert_eq!(state.name(), None);
+    }
+}


### PR DESCRIPTION
### Motivation

- Separate transaction boundary handling from statement execution and centralize transaction bookkeeping in a dedicated manager. 
- Track pager-level transaction state and dirty pages more explicitly to prepare for future MVCC and WAL improvements. 

### Description

- Add a `transaction` module with `TransactionManager`, `statement_requires_transaction` classifier, and `TransactionState`/`TransactionMode` types to encapsulate transaction semantics. 
- Replace inline transaction handling in `Engine::execute` with `TransactionManager::execute`, delegating begin/commit/rollback and implicit transaction logic to the manager. 
- Introduce `DirtyPageSet` for storing modified pages in memory and integrate it into `Pager`, replacing the previous `HashMap` and the boolean `transaction_active` flag with `TransactionState`. 
- Update `Pager` methods (`get_page`, `flush_page`, `begin_transaction`, `commit_transaction`, `rollback_transaction`) to use the new `dirty_pages` API and `TransactionState` helpers and to take snapshots/iterate page numbers when committing/rolling back. 

### Testing

- Ran unit tests and `cargo test`, which executed the `transaction::classifier` test `identifies_mutating_statements` and the `transaction::state` test `transaction_state_tracks_lifecycle`, and they passed. 
- Existing test suite completed without failures on the modified modules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ec08c74c88333a550c4ae37a0265e)