### PR TITLE
Add process-local TransactionId and MVCC Snapshots

### DIFF
--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -6,6 +6,7 @@ use crate::storage::row::{Row, RowData, ColumnValue, ColumnType};
 use crate::storage::pager::Pager;
 use crate::storage::page::PAGE_SIZE;
 use crate::sql::ast::{Expr};
+use crate::transaction::{Snapshot, TransactionId};
 
 /// In‐memory representation of a table’s metadata.
 #[derive(Debug, Clone)]
@@ -42,6 +43,8 @@ pub struct Catalog {
     indexes: HashMap<String, IndexInfo>,
     sequences: HashMap<String, SequenceInfo>,
     pub(crate) pager: Pager,
+    next_transaction_id: TransactionId,
+    active_tx_ids: Vec<TransactionId>,
 }
 
 impl Catalog {
@@ -96,7 +99,7 @@ impl Catalog {
             }
         }
 
-        Ok(Catalog { tables, indexes: HashMap::new(), sequences, pager })
+        Ok(Catalog { tables, indexes: HashMap::new(), sequences, pager, next_transaction_id: 1, active_tx_ids: Vec::new() })
     }
 
     fn reload_tables(&mut self) -> io::Result<()> {
@@ -181,22 +184,62 @@ impl Catalog {
     }
 
     pub fn begin_transaction(&mut self, name: Option<String>) -> io::Result<()> {
-        debug!("Transaction started with name: {:?}", name);
-        self.pager.begin_transaction(name)
+        if self.transaction_active() {
+            return Err(io::Error::new(io::ErrorKind::Other, "transaction already active"));
+        }
+
+        let transaction_id = self.allocate_transaction_id();
+        let snapshot = Snapshot::new(self.next_transaction_id, self.active_tx_ids.clone());
+
+        debug!("Transaction started with id: {}, snapshot: {:?}, name: {:?}", transaction_id, snapshot, name);
+        self.pager.begin_transaction(transaction_id, snapshot, name)?;
+        self.active_tx_ids.push(transaction_id);
+        Ok(())
     }
 
     pub fn commit_transaction(&mut self) -> io::Result<()> {
-        debug!("Transaction committed");
-        self.pager.commit_transaction()
+        let transaction_id = self.transaction_id();
+        debug!("Transaction committed: {:?}", transaction_id);
+        self.pager.commit_transaction()?;
+        if let Some(transaction_id) = transaction_id {
+            self.finish_transaction_id(transaction_id);
+        }
+        Ok(())
     }
 
     pub fn rollback_transaction(&mut self) -> io::Result<()> {
+        let transaction_id = self.transaction_id();
         self.pager.rollback_transaction()?;
+        if let Some(transaction_id) = transaction_id {
+            self.finish_transaction_id(transaction_id);
+        }
         self.reload_tables()
     }
 
     pub fn transaction_active(&self) -> bool {
         self.pager.transaction_active()
+    }
+
+    pub fn transaction_id(&self) -> Option<TransactionId> {
+        self.pager.transaction_id()
+    }
+
+    pub fn transaction_snapshot(&self) -> Option<&Snapshot> {
+        self.pager.transaction_snapshot()
+    }
+
+    pub fn active_transaction_ids(&self) -> &[TransactionId] {
+        &self.active_tx_ids
+    }
+
+    fn allocate_transaction_id(&mut self) -> TransactionId {
+        let transaction_id = self.next_transaction_id;
+        self.next_transaction_id = self.next_transaction_id.saturating_add(1);
+        transaction_id
+    }
+
+    fn finish_transaction_id(&mut self, transaction_id: TransactionId) {
+        self.active_tx_ids.retain(|active_id| *active_id != transaction_id);
     }
 
     /// Create a new table with `name` and `columns`. Allocates a fresh page for the table’s root,

--- a/src/storage/pager.rs
+++ b/src/storage/pager.rs
@@ -1,5 +1,5 @@
 use crate::storage::{dirty_pages::DirtyPageSet, page::PAGE_SIZE};
-use crate::transaction::{wal::Wal, TransactionState};
+use crate::transaction::{Snapshot, TransactionId, TransactionState, wal::Wal};
 use std::fs::{File, OpenOptions};
 use std::io::{self, Read, Seek, SeekFrom, Write};
 
@@ -151,10 +151,23 @@ impl Pager {
         self.transaction.is_active()
     }
 
-    pub fn begin_transaction(&mut self, name: Option<String>) -> io::Result<()> {
-        self.transaction.begin(name);
+    pub fn begin_transaction(
+        &mut self,
+        id: TransactionId,
+        snapshot: Snapshot,
+        name: Option<String>,
+    ) -> io::Result<()> {
+        self.transaction.begin(id, snapshot, name);
         self.dirty_pages.clear();
         Ok(())
+    }
+
+    pub fn transaction_id(&self) -> Option<TransactionId> {
+        self.transaction.id()
+    }
+
+    pub fn transaction_snapshot(&self) -> Option<&Snapshot> {
+        self.transaction.snapshot()
     }
 
     pub fn commit_transaction(&mut self) -> io::Result<()> {

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -6,4 +6,4 @@ mod state;
 
 pub use classifier::statement_requires_transaction;
 pub use manager::TransactionManager;
-pub use state::{TransactionMode, TransactionState};
+pub use state::{Snapshot, TransactionId, TransactionMode, TransactionState};

--- a/src/transaction/state.rs
+++ b/src/transaction/state.rs
@@ -19,12 +19,40 @@ impl Default for TransactionMode {
     }
 }
 
+/// Process-local transaction identifier. Persistence for this counter will be
+/// added later through WAL/metastore integration.
+pub type TransactionId = u64;
+
+/// MVCC snapshot captured when a transaction starts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Snapshot {
+    pub xmin: TransactionId,
+    pub xmax: TransactionId,
+    pub active_tx_ids: Vec<TransactionId>,
+}
+
+impl Snapshot {
+    pub fn new(xmax: TransactionId, mut active_tx_ids: Vec<TransactionId>) -> Self {
+        active_tx_ids.sort_unstable();
+        active_tx_ids.dedup();
+        let xmin = active_tx_ids.first().copied().unwrap_or(xmax);
+
+        Self {
+            xmin,
+            xmax,
+            active_tx_ids,
+        }
+    }
+}
+
 /// Pager-level transaction bookkeeping. Keeping this state behind a single type
-/// gives future MVCC work one place to add transaction ids, snapshots, and page
-/// version metadata without spreading those fields through the pager.
+/// gives MVCC work one place for transaction ids, snapshots, and page version
+/// metadata without spreading those fields through the pager.
 #[derive(Debug, Default)]
 pub struct TransactionState {
     active: bool,
+    id: Option<TransactionId>,
+    snapshot: Option<Snapshot>,
     name: Option<String>,
 }
 
@@ -33,18 +61,30 @@ impl TransactionState {
         self.active
     }
 
-    pub fn begin(&mut self, name: Option<String>) {
+    pub fn begin(&mut self, id: TransactionId, snapshot: Snapshot, name: Option<String>) {
         self.active = true;
+        self.id = Some(id);
+        self.snapshot = Some(snapshot);
         self.name = name;
     }
 
     pub fn finish(&mut self) {
         self.active = false;
+        self.id = None;
+        self.snapshot = None;
         self.name = None;
     }
 
     pub fn name(&self) -> Option<&str> {
         self.name.as_deref()
+    }
+
+    pub fn id(&self) -> Option<TransactionId> {
+        self.id
+    }
+
+    pub fn snapshot(&self) -> Option<&Snapshot> {
+        self.snapshot.as_ref()
     }
 }
 
@@ -57,12 +97,17 @@ mod tests {
         let mut state = TransactionState::default();
         assert!(!state.is_active());
 
-        state.begin(Some("tx".to_string()));
+        let snapshot = Snapshot::new(2, vec![1]);
+        state.begin(2, snapshot.clone(), Some("tx".to_string()));
         assert!(state.is_active());
+        assert_eq!(state.id(), Some(2));
+        assert_eq!(state.snapshot(), Some(&snapshot));
         assert_eq!(state.name(), Some("tx"));
 
         state.finish();
         assert!(!state.is_active());
+        assert_eq!(state.id(), None);
+        assert_eq!(state.snapshot(), None);
         assert_eq!(state.name(), None);
     }
 }


### PR DESCRIPTION
### Motivation

- Introduce transaction identifiers and snapshots to enable MVCC-style visibility and prepare for persistent transaction numbering via WAL/metastore. 
- Keep transaction lifecycle metadata together so pager and catalog can maintain and observe per-transaction context for commits/rollbacks. 

### Description

- Add `TransactionId` (alias `u64`) and `Snapshot { xmin, xmax, active_tx_ids }` in `src/transaction/state.rs` and export them from the transaction module via `src/transaction/mod.rs`. 
- Extend `TransactionState` to store the active `id` and `snapshot` and expose `id()` and `snapshot()` accessors while preserving `name()` and lifecycle methods. 
- Change `Pager` API in `src/storage/pager.rs` to accept `(id, snapshot, name)` on `begin_transaction`, store that metadata, and expose `transaction_id()` and `transaction_snapshot()` accessors. 
- Add monotonic, process-local transaction id generation and active-id bookkeeping in `Catalog` (`src/catalog/mod.rs`), create snapshots from the current active transaction ids on `begin_transaction`, and remove the id on `commit_transaction`/`rollback_transaction`; preserve implicit/explicit behavior via the existing `TransactionManager` flow. 

### Testing

- Ran the full test suite with `cargo test`, and all tests completed successfully. 
- Existing unit tests including `transaction::state::tests::transaction_state_tracks_lifecycle` passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f8437613483339a73cd6a0b7b8fa0)