### PR TITLE
Add MVCC-aware row payload format and row metadata

### DIFF
--- a/src/execution/runtime.rs
+++ b/src/execution/runtime.rs
@@ -1409,10 +1409,10 @@ mod tests {
 
     #[test]
     fn format_row_simple() {
-        let row = Row {
-            key: 1,
-            data: RowData(vec![ColumnValue::Integer(1), ColumnValue::Text("bob".into())]),
-        };
+        let row = Row::new(
+            1,
+            RowData(vec![ColumnValue::Integer(1), ColumnValue::Text("bob".into())]),
+        );
         assert_eq!(format_row(&row), "1 | bob");
     }
 

--- a/src/storage/btree.rs
+++ b/src/storage/btree.rs
@@ -1,8 +1,11 @@
-use std::io;
-use log::debug;
+use crate::storage::page::{
+    get_cell_count, get_next_leaf, get_node_type, get_parent, set_cell_count, set_is_root,
+    set_next_leaf, set_node_type, set_parent, HEADER_SIZE, NODE_INTERNAL, NODE_LEAF, PAGE_SIZE,
+};
 use crate::storage::pager::Pager;
-use crate::storage::row::{Row, RowData, ColumnValue};
-use crate::storage::page::{get_cell_count, get_node_type, set_cell_count, set_node_type, set_parent, set_is_root, NODE_LEAF, HEADER_SIZE, PAGE_SIZE, NODE_INTERNAL, get_parent, get_next_leaf, set_next_leaf};
+use crate::storage::row::{Row, RowData};
+use log::debug;
+use std::io;
 
 /// store multiple separator keys and child pointers.
 ///
@@ -39,8 +42,6 @@ use crate::storage::page::{get_cell_count, get_node_type, set_cell_count, set_no
 ///   5. If you reach the root and it overflows, allocate a new root page, make it internal,
 ///        with two children (old_root and new_internal), and update their parent pointers.
 ///—————————————————————————————————————————————————————————————————————————————————————————————
-
-
 
 pub struct BTree<'a> {
     root_page: u32,
@@ -123,10 +124,7 @@ impl<'a> BTree<'a> {
             offset += 4;
 
             if key < key_i {
-                debug!(
-                    "  → Descending to child {} (key < {})",
-                    child_page, key_i
-                );
+                debug!("  → Descending to child {} (key < {})", child_page, key_i);
                 // Descend to `child_page`
                 return self.find_in_page(child_page, key);
             } else {
@@ -167,13 +165,16 @@ impl<'a> BTree<'a> {
             if get_node_type(&page.data) == NODE_LEAF {
                 break;
             }
-            let left_child = u32::from_le_bytes(page.data[HEADER_SIZE..HEADER_SIZE + 4].try_into().unwrap());
+            let left_child =
+                u32::from_le_bytes(page.data[HEADER_SIZE..HEADER_SIZE + 4].try_into().unwrap());
             page_num = left_child;
         }
         loop {
             all_rows.extend(self.read_all_rows_from_leaf(page_num)?);
             let next = get_next_leaf(&self.pager.get_page(page_num)?.data);
-            if next == 0 { break; }
+            if next == 0 {
+                break;
+            }
             page_num = next;
         }
         let original = all_rows.len();
@@ -248,7 +249,7 @@ impl<'a> BTree<'a> {
             }
 
             // Insert new row and sort
-            rows.push(Row { key, data: data.clone() });
+            rows.push(Row::new(key, data.clone()));
             rows.sort_by_key(|r| r.key);
 
             // Try writing back to leaf
@@ -332,8 +333,6 @@ impl<'a> BTree<'a> {
             get_next_leaf(&left_page.data)
         };
 
-
-
         // —————————————————————————
         // 2) Allocate a new leaf page. Initialize its header properly:
         //    NODE_TYPE = LEAF, IS_ROOT = false, PARENT = 0 (temporarily),
@@ -350,7 +349,6 @@ impl<'a> BTree<'a> {
             set_next_leaf(&mut p.data, 0);
             self.pager.flush_page(new_leaf)?;
         }
-
 
         // —————————————————————————
         // 3) Rewrite left half back into leaf_page_num
@@ -389,7 +387,6 @@ impl<'a> BTree<'a> {
         self.insert_in_parent(leaf_page_num, separator_key, new_leaf)
     }
 
-
     /// Insert a new (separator_key, new_child_page) entry into the parent of `old_page`.
     ///
     /// If `old_page` was the root, create a new root (internal) at page 0 or a newly allocated page.
@@ -419,15 +416,12 @@ impl<'a> BTree<'a> {
                 set_parent(&mut root.data, 0); // root’s parent = 0
 
                 // Leftmost child pointer = old_page
-                root.data[HEADER_SIZE..HEADER_SIZE + 4]
-                    .copy_from_slice(&old_page.to_le_bytes());
+                root.data[HEADER_SIZE..HEADER_SIZE + 4].copy_from_slice(&old_page.to_le_bytes());
 
                 // One separator: [separator_key][new_page]
                 let offset = HEADER_SIZE + 4;
-                root.data[offset..offset + 4]
-                    .copy_from_slice(&separator_key.to_le_bytes());
-                root.data[offset + 4..offset + 8]
-                    .copy_from_slice(&new_page.to_le_bytes());
+                root.data[offset..offset + 4].copy_from_slice(&separator_key.to_le_bytes());
+                root.data[offset + 4..offset + 8].copy_from_slice(&new_page.to_le_bytes());
 
                 // Set cell_count = 1
                 set_cell_count(&mut root.data, 1);
@@ -611,8 +605,7 @@ impl<'a> BTree<'a> {
                 set_cell_count(&mut nr.data, 1);
 
                 // Leftmost child = old root (page_num)
-                nr.data[HEADER_SIZE..HEADER_SIZE + 4]
-                    .copy_from_slice(&page_num.to_le_bytes());
+                nr.data[HEADER_SIZE..HEADER_SIZE + 4].copy_from_slice(&page_num.to_le_bytes());
 
                 // One separator: [separator_key][new_internal]
                 let off = HEADER_SIZE + 4;
@@ -668,17 +661,10 @@ impl<'a> BTree<'a> {
 
         for _ in 0..cell_count {
             // 1) 4 bytes key
-            let key = i32::from_le_bytes(
-                page.data[offset..offset + 4]
-                    .try_into()
-                    .unwrap(),
-            );
+            let key = i32::from_le_bytes(page.data[offset..offset + 4].try_into().unwrap());
             // 2) 4 bytes payload length
-            let payload_len = u32::from_le_bytes(
-                page.data[offset + 4..offset + 8]
-                    .try_into()
-                    .unwrap(),
-            ) as usize;
+            let payload_len =
+                u32::from_le_bytes(page.data[offset + 4..offset + 8].try_into().unwrap()) as usize;
             // 3) payload bytes
             let start = offset + 8;
             let end = start + payload_len;
@@ -689,15 +675,14 @@ impl<'a> BTree<'a> {
                 ));
             }
             let bytes = &page.data[start..end];
-            let data = RowData::deserialize(bytes)?;
+            let row = Row::deserialize_mvcc_payload(key, bytes)?;
 
-            rows.push(Row { key, data });
+            rows.push(row);
             offset = end;
         }
 
         Ok(rows)
     }
-
 
     /// Write a complete sorted list of rows into a leaf page.
     fn write_all_rows_to_leaf(&mut self, page_num: u32, rows: &[Row]) -> io::Result<()> {
@@ -706,7 +691,7 @@ impl<'a> BTree<'a> {
         // 1) Compute total size of all row‐bodies (4B key + 4B length + payload.len())
         let mut total_size: usize = 0;
         for row in rows {
-            let bytes = row.data.serialize();
+            let bytes = row.serialize_mvcc_payload();
             total_size += 4; // key
             total_size += 4; // length
             total_size += bytes.len();
@@ -728,7 +713,7 @@ impl<'a> BTree<'a> {
         // 4) Pack each row at offset = HEADER_SIZE
         let mut offset = HEADER_SIZE;
         for row in rows {
-            let bytes = row.data.serialize();
+            let bytes = row.serialize_mvcc_payload();
             // 4A: 4 bytes for key
             let key_bytes = row.key.to_le_bytes();
             page.data[offset..offset + 4].copy_from_slice(&key_bytes);
@@ -862,11 +847,7 @@ impl<'a> BTree<'a> {
         self.scan_rows_with_bounds(0, None)
     }
 
-    pub fn scan_rows_with_bounds(
-        &'a mut self,
-        skip: usize,
-        limit: Option<usize>,
-    ) -> RowCursor<'a> {
+    pub fn scan_rows_with_bounds(&'a mut self, skip: usize, limit: Option<usize>) -> RowCursor<'a> {
         // 1) Find leftmost leaf
         let mut page_num = self.root_page;
         loop {
@@ -889,11 +870,7 @@ impl<'a> BTree<'a> {
         }
     }
 
-    pub fn scan_rows_desc_with_bounds(
-        &'a mut self,
-        skip: usize,
-        limit: Option<usize>,
-    ) -> Vec<Row> {
+    pub fn scan_rows_desc_with_bounds(&'a mut self, skip: usize, limit: Option<usize>) -> Vec<Row> {
         let mut rows: Vec<Row> = self.scan_rows_with_bounds(0, None).collect();
         rows.reverse();
         let start = skip.min(rows.len());
@@ -946,8 +923,7 @@ impl<'b> Iterator for RowCursor<'b> {
                     return None;
                 }
                 let bytes = &page.data[start..end];
-                let data = RowData::deserialize(bytes).ok()?;
-                let row = Row { key, data };
+                let row = Row::deserialize_mvcc_payload(key, bytes).ok()?;
 
                 // Advance offsets
                 self.offset = end;

--- a/src/storage/row.rs
+++ b/src/storage/row.rs
@@ -1,14 +1,26 @@
 use std::io;
 
+use crate::transaction::TransactionId;
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ColumnType {
     Integer,
     Text,
     Boolean,
     Char(usize),
-    SmallInt { width: usize, unsigned: bool },
-    MediumInt { width: usize, unsigned: bool },
-    Double { precision: usize, scale: usize, unsigned: bool },
+    SmallInt {
+        width: usize,
+        unsigned: bool,
+    },
+    MediumInt {
+        width: usize,
+        unsigned: bool,
+    },
+    Double {
+        precision: usize,
+        scale: usize,
+        unsigned: bool,
+    },
     Date,
     DateTime,
     Timestamp,
@@ -76,7 +88,10 @@ impl ColumnType {
                     let args = &base[start + 1..end];
                     let parts: Vec<&str> = args.split(',').collect();
                     if parts.len() == 2 {
-                        if let (Ok(p), Ok(s)) = (parts[0].trim().parse::<usize>(), parts[1].trim().parse::<usize>()) {
+                        if let (Ok(p), Ok(s)) = (
+                            parts[0].trim().parse::<usize>(),
+                            parts[1].trim().parse::<usize>(),
+                        ) {
                             if p <= 255 && s <= 255 && p >= s {
                                 precision = p;
                                 scale = s;
@@ -88,7 +103,11 @@ impl ColumnType {
                 }
                 base = &base[..start];
             }
-            return Some(ColumnType::Double { precision, scale, unsigned });
+            return Some(ColumnType::Double {
+                precision,
+                scale,
+                unsigned,
+            });
         }
         if base == "DATE" {
             return Some(ColumnType::Date);
@@ -121,19 +140,33 @@ impl ColumnType {
             ColumnType::Char(size) => format!("CHAR({})", size),
             ColumnType::SmallInt { width, unsigned } => {
                 let mut s = String::from("SMALLINT");
-                if *width > 0 { s.push_str(&format!("({})", width)); }
-                if *unsigned { s.push_str(" UNSIGNED"); }
+                if *width > 0 {
+                    s.push_str(&format!("({})", width));
+                }
+                if *unsigned {
+                    s.push_str(" UNSIGNED");
+                }
                 s
             }
             ColumnType::MediumInt { width, unsigned } => {
                 let mut s = String::from("MEDIUMINT");
-                if *width > 0 { s.push_str(&format!("({})", width)); }
-                if *unsigned { s.push_str(" UNSIGNED"); }
+                if *width > 0 {
+                    s.push_str(&format!("({})", width));
+                }
+                if *unsigned {
+                    s.push_str(" UNSIGNED");
+                }
                 s
             }
-            ColumnType::Double { precision, scale, unsigned } => {
+            ColumnType::Double {
+                precision,
+                scale,
+                unsigned,
+            } => {
                 let mut s = format!("DOUBLE({},{})", precision, scale);
-                if *unsigned { s.push_str(" UNSIGNED"); }
+                if *unsigned {
+                    s.push_str(" UNSIGNED");
+                }
                 s
             }
             ColumnType::Date => "DATE".into(),
@@ -150,9 +183,19 @@ impl ColumnType {
             2 => Some(ColumnType::Text),
             3 => Some(ColumnType::Boolean),
             4 => Some(ColumnType::Char(0)),
-            5 => Some(ColumnType::SmallInt { width: 0, unsigned: false }),
-            6 => Some(ColumnType::MediumInt { width: 0, unsigned: false }),
-            7 => Some(ColumnType::Double { precision: 10, scale: 0, unsigned: false }),
+            5 => Some(ColumnType::SmallInt {
+                width: 0,
+                unsigned: false,
+            }),
+            6 => Some(ColumnType::MediumInt {
+                width: 0,
+                unsigned: false,
+            }),
+            7 => Some(ColumnType::Double {
+                precision: 10,
+                scale: 0,
+                unsigned: false,
+            }),
             8 => Some(ColumnType::Date),
             9 => Some(ColumnType::DateTime),
             10 => Some(ColumnType::Timestamp),
@@ -197,6 +240,15 @@ pub enum ColumnValue {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct RowData(pub Vec<ColumnValue>);
+
+/// Transaction id assigned to rows that were written before row-level MVCC
+/// metadata existed on disk.  Real transaction ids start at 1 today, so 0 is
+/// reserved as a committed bootstrap transaction for legacy payloads.
+pub const COMMITTED_BOOTSTRAP_TX: TransactionId = 0;
+
+/// Current row payload format.  The high-bit marker keeps the version byte out
+/// of the range normally used by the low byte of small legacy column counts.
+pub const MVCC_ROW_PAYLOAD_FORMAT_VERSION: u8 = 0x81;
 
 impl RowData {
     pub fn serialize(&self) -> Vec<u8> {
@@ -284,7 +336,8 @@ impl RowData {
                     if offset + 4 > bytes.len() {
                         return Err(io::Error::new(io::ErrorKind::Other, "EOF"));
                     }
-                    let len = u32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap()) as usize;
+                    let len =
+                        u32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap()) as usize;
                     offset += 4;
                     if offset + len > bytes.len() {
                         return Err(io::Error::new(io::ErrorKind::Other, "EOF"));
@@ -305,7 +358,8 @@ impl RowData {
                     if offset + 4 > bytes.len() {
                         return Err(io::Error::new(io::ErrorKind::Other, "EOF"));
                     }
-                    let len = u32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap()) as usize;
+                    let len =
+                        u32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap()) as usize;
                     offset += 4;
                     if offset + len > bytes.len() {
                         return Err(io::Error::new(io::ErrorKind::Other, "EOF"));
@@ -374,9 +428,16 @@ impl RowData {
 /// Build a `RowData` from raw string values according to the declared column
 /// types. Returns an error if any value cannot be converted or the counts do
 /// not match.
-pub fn build_row_data(values: &[String], columns: &[(String, ColumnType)]) -> Result<RowData, String> {
+pub fn build_row_data(
+    values: &[String],
+    columns: &[(String, ColumnType)],
+) -> Result<RowData, String> {
     if values.len() != columns.len() {
-        return Err(format!("Expected {} values, got {}", columns.len(), values.len()));
+        return Err(format!(
+            "Expected {} values, got {}",
+            columns.len(),
+            values.len()
+        ));
     }
     let mut cols = Vec::with_capacity(columns.len());
     for (v, (name, ty)) in values.iter().zip(columns.iter()) {
@@ -388,7 +449,10 @@ pub fn build_row_data(values: &[String], columns: &[(String, ColumnType)]) -> Re
             ColumnType::Integer => match v.parse::<i32>() {
                 Ok(i) => cols.push(ColumnValue::Integer(i)),
                 Err(_) => {
-                    return Err(format!("Value '{}' for column '{}' is not a valid INTEGER", v, name));
+                    return Err(format!(
+                        "Value '{}' for column '{}' is not a valid INTEGER",
+                        v, name
+                    ));
                 }
             },
             ColumnType::Text => cols.push(ColumnValue::Text(v.clone())),
@@ -396,7 +460,10 @@ pub fn build_row_data(values: &[String], columns: &[(String, ColumnType)]) -> Re
                 "true" => cols.push(ColumnValue::Boolean(true)),
                 "false" => cols.push(ColumnValue::Boolean(false)),
                 _ => {
-                    return Err(format!("Value '{}' for column '{}' is not a valid BOOLEAN", v, name));
+                    return Err(format!(
+                        "Value '{}' for column '{}' is not a valid BOOLEAN",
+                        v, name
+                    ));
                 }
             },
             ColumnType::Char(len) => {
@@ -414,7 +481,10 @@ pub fn build_row_data(values: &[String], columns: &[(String, ColumnType)]) -> Re
             }
             ColumnType::SmallInt { unsigned, .. } => {
                 let val = v.parse::<i32>().map_err(|_| {
-                    format!("Value '{}' for column '{}' is not a valid SMALLINT", v, name)
+                    format!(
+                        "Value '{}' for column '{}' is not a valid SMALLINT",
+                        v, name
+                    )
                 })?;
                 if *unsigned {
                     if !(0..=65535).contains(&val) {
@@ -427,7 +497,10 @@ pub fn build_row_data(values: &[String], columns: &[(String, ColumnType)]) -> Re
             }
             ColumnType::MediumInt { unsigned, .. } => {
                 let val = v.parse::<i32>().map_err(|_| {
-                    format!("Value '{}' for column '{}' is not a valid MEDIUMINT", v, name)
+                    format!(
+                        "Value '{}' for column '{}' is not a valid MEDIUMINT",
+                        v, name
+                    )
                 })?;
                 if *unsigned {
                     if !(0..=16_777_215).contains(&val) {
@@ -447,55 +520,184 @@ pub fn build_row_data(values: &[String], columns: &[(String, ColumnType)]) -> Re
                 }
                 cols.push(ColumnValue::Double(val));
             }
-            ColumnType::Date => {
-                match parse_date(v) {
-                    Some(d) => cols.push(ColumnValue::Date(d)),
-                    None => {
-                        return Err(format!("Value '{}' for column '{}' is not a valid DATE", v, name));
-                    }
+            ColumnType::Date => match parse_date(v) {
+                Some(d) => cols.push(ColumnValue::Date(d)),
+                None => {
+                    return Err(format!(
+                        "Value '{}' for column '{}' is not a valid DATE",
+                        v, name
+                    ));
                 }
-            }
-            ColumnType::DateTime => {
-                match parse_datetime(v) {
-                    Some(ts) => cols.push(ColumnValue::DateTime(ts)),
-                    None => {
-                        return Err(format!("Value '{}' for column '{}' is not a valid DATETIME", v, name));
-                    }
+            },
+            ColumnType::DateTime => match parse_datetime(v) {
+                Some(ts) => cols.push(ColumnValue::DateTime(ts)),
+                None => {
+                    return Err(format!(
+                        "Value '{}' for column '{}' is not a valid DATETIME",
+                        v, name
+                    ));
                 }
-            }
-            ColumnType::Timestamp => {
-                match parse_datetime(v) {
-                    Some(ts) => cols.push(ColumnValue::Timestamp(ts)),
-                    None => {
-                        return Err(format!("Value '{}' for column '{}' is not a valid TIMESTAMP", v, name));
-                    }
+            },
+            ColumnType::Timestamp => match parse_datetime(v) {
+                Some(ts) => cols.push(ColumnValue::Timestamp(ts)),
+                None => {
+                    return Err(format!(
+                        "Value '{}' for column '{}' is not a valid TIMESTAMP",
+                        v, name
+                    ));
                 }
-            }
-            ColumnType::Time => {
-                match parse_time(v) {
-                    Some(t) => cols.push(ColumnValue::Time(t)),
-                    None => {
-                        return Err(format!("Value '{}' for column '{}' is not a valid TIME", v, name));
-                    }
+            },
+            ColumnType::Time => match parse_time(v) {
+                Some(t) => cols.push(ColumnValue::Time(t)),
+                None => {
+                    return Err(format!(
+                        "Value '{}' for column '{}' is not a valid TIME",
+                        v, name
+                    ));
                 }
-            }
-            ColumnType::Year => {
-                match parse_year(v) {
-                    Some(y) => cols.push(ColumnValue::Year(y)),
-                    None => {
-                        return Err(format!("Value '{}' for column '{}' is not a valid YEAR", v, name));
-                    }
+            },
+            ColumnType::Year => match parse_year(v) {
+                Some(y) => cols.push(ColumnValue::Year(y)),
+                None => {
+                    return Err(format!(
+                        "Value '{}' for column '{}' is not a valid YEAR",
+                        v, name
+                    ));
                 }
-            }
+            },
         }
     }
     Ok(RowData(cols))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RowVersionRef {
+    pub page_num: u32,
+    pub slot_index: u16,
 }
 
 #[derive(Debug, Clone)]
 pub struct Row {
     pub key: i32,
     pub data: RowData,
+    pub created_tx: TransactionId,
+    pub deleted_tx: Option<TransactionId>,
+    pub version_ptr: Option<RowVersionRef>,
+}
+
+impl Row {
+    pub fn new(key: i32, data: RowData) -> Self {
+        Self {
+            key,
+            data,
+            created_tx: COMMITTED_BOOTSTRAP_TX,
+            deleted_tx: None,
+            version_ptr: None,
+        }
+    }
+
+    pub fn serialize_mvcc_payload(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.push(MVCC_ROW_PAYLOAD_FORMAT_VERSION);
+        buf.extend(&self.created_tx.to_le_bytes());
+        match self.deleted_tx {
+            Some(deleted_tx) => {
+                buf.push(1);
+                buf.extend(&deleted_tx.to_le_bytes());
+            }
+            None => buf.push(0),
+        }
+        match self.version_ptr {
+            Some(version_ptr) => {
+                buf.push(1);
+                buf.extend(&version_ptr.page_num.to_le_bytes());
+                buf.extend(&version_ptr.slot_index.to_le_bytes());
+            }
+            None => buf.push(0),
+        }
+        buf.extend(self.data.serialize());
+        buf
+    }
+
+    pub fn deserialize_mvcc_payload(key: i32, bytes: &[u8]) -> io::Result<Self> {
+        if bytes.first().copied() != Some(MVCC_ROW_PAYLOAD_FORMAT_VERSION) {
+            return Ok(Self {
+                key,
+                data: RowData::deserialize(bytes)?,
+                created_tx: COMMITTED_BOOTSTRAP_TX,
+                deleted_tx: None,
+                version_ptr: None,
+            });
+        }
+
+        let mut offset = 1;
+        if offset + 8 > bytes.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "MVCC row missing created_tx",
+            ));
+        }
+        let created_tx =
+            TransactionId::from_le_bytes(bytes[offset..offset + 8].try_into().unwrap());
+        offset += 8;
+
+        if offset >= bytes.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "MVCC row missing deleted_tx flag",
+            ));
+        }
+        let deleted_tx = if bytes[offset] == 0 {
+            offset += 1;
+            None
+        } else {
+            offset += 1;
+            if offset + 8 > bytes.len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    "MVCC row missing deleted_tx",
+                ));
+            }
+            let tx = TransactionId::from_le_bytes(bytes[offset..offset + 8].try_into().unwrap());
+            offset += 8;
+            Some(tx)
+        };
+
+        if offset >= bytes.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "MVCC row missing version_ptr flag",
+            ));
+        }
+        let version_ptr = if bytes[offset] == 0 {
+            offset += 1;
+            None
+        } else {
+            offset += 1;
+            if offset + 6 > bytes.len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    "MVCC row missing version_ptr",
+                ));
+            }
+            let page_num = u32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap());
+            offset += 4;
+            let slot_index = u16::from_le_bytes(bytes[offset..offset + 2].try_into().unwrap());
+            offset += 2;
+            Some(RowVersionRef {
+                page_num,
+                slot_index,
+            })
+        };
+
+        Ok(Self {
+            key,
+            data: RowData::deserialize(&bytes[offset..])?,
+            created_tx,
+            deleted_tx,
+            version_ptr,
+        })
+    }
 }
 
 impl ColumnValue {
@@ -508,14 +710,17 @@ impl ColumnValue {
             ColumnValue::Char(s) => s.clone(),
             ColumnValue::Double(f) => f.to_string(),
             ColumnValue::Date(d) => {
-                use chrono::{NaiveDate, Duration};
-                let epoch = NaiveDate::from_ymd_opt(1970,1,1).unwrap();
+                use chrono::{Duration, NaiveDate};
+                let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
                 let date = epoch + Duration::days(*d as i64);
                 date.format("%Y-%m-%d").to_string()
             }
             ColumnValue::DateTime(ts) | ColumnValue::Timestamp(ts) => {
                 use chrono::NaiveDateTime;
-                NaiveDateTime::from_timestamp_opt(*ts, 0).unwrap().format("%Y-%m-%d %H:%M:%S").to_string()
+                NaiveDateTime::from_timestamp_opt(*ts, 0)
+                    .unwrap()
+                    .format("%Y-%m-%d %H:%M:%S")
+                    .to_string()
             }
             ColumnValue::Time(t) => {
                 let neg = *t < 0;
@@ -548,18 +753,75 @@ pub(crate) fn parse_time(s: &str) -> Option<i32> {
     let neg = s.starts_with('-');
     let t = if neg { &s[1..] } else { s };
     let parts: Vec<&str> = t.split(':').collect();
-    if parts.len() != 3 { return None; }
+    if parts.len() != 3 {
+        return None;
+    }
     let h: i32 = parts[0].parse().ok()?;
     let m: i32 = parts[1].parse().ok()?;
     let sec: i32 = parts[2].parse().ok()?;
-    if h > 838 || m > 59 || sec > 59 { return None; }
+    if h > 838 || m > 59 || sec > 59 {
+        return None;
+    }
     let mut total = h * 3600 + m * 60 + sec;
-    if neg { total = -total; }
+    if neg {
+        total = -total;
+    }
     Some(total)
 }
 
 pub(crate) fn parse_year(s: &str) -> Option<u16> {
-    if s.len() != 4 { return None; }
+    if s.len() != 4 {
+        return None;
+    }
     let y: u16 = s.parse().ok()?;
-    if y == 0 || (1901..=2155).contains(&y) { Some(y) } else { None }
+    if y == 0 || (1901..=2155).contains(&y) {
+        Some(y)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod mvcc_tests {
+    use super::*;
+
+    #[test]
+    fn mvcc_payload_round_trips_metadata_and_column_encoding() {
+        let row = Row {
+            key: 7,
+            data: RowData(vec![
+                ColumnValue::Integer(42),
+                ColumnValue::Text("alice".into()),
+            ]),
+            created_tx: 12,
+            deleted_tx: Some(15),
+            version_ptr: Some(RowVersionRef {
+                page_num: 3,
+                slot_index: 2,
+            }),
+        };
+
+        let payload = row.serialize_mvcc_payload();
+        assert_eq!(payload[0], MVCC_ROW_PAYLOAD_FORMAT_VERSION);
+
+        let decoded = Row::deserialize_mvcc_payload(row.key, &payload).unwrap();
+        assert_eq!(decoded.key, row.key);
+        assert_eq!(decoded.data, row.data);
+        assert_eq!(decoded.created_tx, row.created_tx);
+        assert_eq!(decoded.deleted_tx, row.deleted_tx);
+        assert_eq!(decoded.version_ptr, row.version_ptr);
+    }
+
+    #[test]
+    fn legacy_payload_defaults_to_committed_bootstrap_metadata() {
+        let data = RowData(vec![ColumnValue::Boolean(true)]);
+        let legacy_payload = data.serialize();
+
+        let decoded = Row::deserialize_mvcc_payload(9, &legacy_payload).unwrap();
+        assert_eq!(decoded.key, 9);
+        assert_eq!(decoded.data, data);
+        assert_eq!(decoded.created_tx, COMMITTED_BOOTSTRAP_TX);
+        assert_eq!(decoded.deleted_tx, None);
+        assert_eq!(decoded.version_ptr, None);
+    }
 }


### PR DESCRIPTION
### Motivation
- Introduce row-level MVCC metadata so rows can carry `created_tx`, optional `deleted_tx`, and a `version_ptr` for multi-version linking while preserving existing column encoding.

### Description
- Add `COMMITTED_BOOTSTRAP_TX` and `MVCC_ROW_PAYLOAD_FORMAT_VERSION` constants and a `RowVersionRef` type, and extend `Row` with `created_tx: TransactionId`, `deleted_tx: Option<TransactionId>`, and `version_ptr: Option<RowVersionRef>`.
- Implement MVCC-aware payload wrappers `Row::serialize_mvcc_payload` and `Row::deserialize_mvcc_payload` that prepend/read a format version byte and metadata, and fall back to legacy `RowData::deserialize` with `created_tx = COMMITTED_BOOTSTRAP_TX` and `deleted_tx = None` for compatibility.
- Keep `RowData` column encoding unchanged and wrap it instead of modifying `RowData::serialize`/`deserialize`.
- Update B-Tree code paths (`read_all_rows_from_leaf`, `write_all_rows_to_leaf`, `RowCursor`, and insert code) to use `Row::deserialize_mvcc_payload` / `Row::serialize_mvcc_payload` and to construct new rows via `Row::new`.
- Add unit tests exercising MVCC payload round-trip and legacy payload fallback and update an existing runtime test to construct a `Row` via `Row::new`.

### Testing
- Ran `cargo test`, which executed the full test suite and completed with all tests passing.
- Ran `cargo test storage::row::mvcc_tests --lib` which passed and verified the new `mvcc_tests` (`mvcc_payload_round_trips_metadata_and_column_encoding` and `legacy_payload_defaults_to_committed_bootstrap_metadata`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f8744e8448333ae08abc6b47e4768)