### PR TITLE
Add MVCC visibility helper and snapshot current_tx tracking

### DIFF
--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -189,7 +189,7 @@ impl Catalog {
         }
 
         let transaction_id = self.allocate_transaction_id();
-        let snapshot = Snapshot::new(self.next_transaction_id, self.active_tx_ids.clone());
+        let snapshot = Snapshot::new_for_transaction(transaction_id, self.next_transaction_id, self.active_tx_ids.clone());
 
         debug!("Transaction started with id: {}, snapshot: {:?}, name: {:?}", transaction_id, snapshot, name);
         self.pager.begin_transaction(transaction_id, snapshot, name)?;
@@ -226,6 +226,10 @@ impl Catalog {
 
     pub fn transaction_snapshot(&self) -> Option<&Snapshot> {
         self.pager.transaction_snapshot()
+    }
+
+    pub fn current_snapshot(&self) -> Option<Snapshot> {
+        self.transaction_snapshot().cloned()
     }
 
     pub fn active_transaction_ids(&self) -> &[TransactionId] {

--- a/src/storage/btree.rs
+++ b/src/storage/btree.rs
@@ -4,7 +4,9 @@ use crate::storage::page::{
 };
 use crate::storage::pager::Pager;
 use crate::storage::row::{Row, RowData, COMMITTED_BOOTSTRAP_TX};
-use crate::transaction::{Snapshot, TransactionId};
+use crate::transaction::{
+    is_visible, Snapshot, TransactionId, TransactionStatus, TransactionTable,
+};
 use log::debug;
 use std::io;
 
@@ -100,24 +102,29 @@ impl<'a> BTree<'a> {
     }
 
     fn find_latest_logical(&mut self, key: i32) -> io::Result<Option<Row>> {
-        let snapshot = Snapshot {
-            xmin: COMMITTED_BOOTSTRAP_TX,
-            xmax: TransactionId::MAX,
-            active_tx_ids: Vec::new(),
-        };
+        let snapshot = Snapshot::new(TransactionId::MAX, Vec::new());
         self.find_visible(key, &snapshot)
     }
 
     fn row_visible(row: &Row, snapshot: &Snapshot) -> bool {
-        let created_visible = row.created_tx < snapshot.xmax
+        let mut tx_table = TransactionTable::new();
+        tx_table.insert(COMMITTED_BOOTSTRAP_TX, TransactionStatus::Committed);
+        if row.created_tx < snapshot.xmax
             && !snapshot
                 .active_tx_ids
                 .binary_search(&row.created_tx)
-                .is_ok();
-        let deleted_visible = row.deleted_tx.map(|deleted_tx| {
-            deleted_tx < snapshot.xmax && !snapshot.active_tx_ids.binary_search(&deleted_tx).is_ok()
-        });
-        created_visible && !deleted_visible.unwrap_or(false)
+                .is_ok()
+        {
+            tx_table.insert(row.created_tx, TransactionStatus::Committed);
+        }
+        if let Some(deleted_tx) = row.deleted_tx {
+            if deleted_tx < snapshot.xmax
+                && !snapshot.active_tx_ids.binary_search(&deleted_tx).is_ok()
+            {
+                tx_table.insert(deleted_tx, TransactionStatus::Committed);
+            }
+        }
+        is_visible(row, snapshot, &tx_table)
     }
 
     /// Recursive helper to find a key starting at page `page_num`.
@@ -203,11 +210,7 @@ impl<'a> BTree<'a> {
 
     /// Mark the newest visible version of `key` as deleted without physically rebuilding the tree.
     pub fn mark_deleted(&mut self, key: i32, deleted_tx: TransactionId) -> io::Result<bool> {
-        let snapshot = Snapshot {
-            xmin: COMMITTED_BOOTSTRAP_TX,
-            xmax: TransactionId::MAX,
-            active_tx_ids: Vec::new(),
-        };
+        let snapshot = Snapshot::new(TransactionId::MAX, Vec::new());
         let Some(target) = self.find_visible(key, &snapshot)? else {
             return Ok(false);
         };

--- a/src/transaction/manager.rs
+++ b/src/transaction/manager.rs
@@ -15,6 +15,10 @@ impl TransactionManager {
         Self::default()
     }
 
+    pub fn current_snapshot(&self, catalog: &Catalog) -> Option<crate::transaction::Snapshot> {
+        catalog.current_snapshot()
+    }
+
     pub fn execute<F>(
         &mut self,
         catalog: &mut Catalog,

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -1,3 +1,4 @@
+pub mod mvcc;
 pub mod wal;
 
 mod classifier;
@@ -6,4 +7,5 @@ mod state;
 
 pub use classifier::statement_requires_transaction;
 pub use manager::TransactionManager;
+pub use mvcc::{is_visible, TransactionStatus, TransactionTable};
 pub use state::{Snapshot, TransactionId, TransactionMode, TransactionState};

--- a/src/transaction/mvcc.rs
+++ b/src/transaction/mvcc.rs
@@ -1,0 +1,105 @@
+use std::collections::HashMap;
+
+use crate::storage::row::{Row, COMMITTED_BOOTSTRAP_TX};
+
+use super::{Snapshot, TransactionId};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransactionStatus {
+    Active,
+    Committed,
+    Aborted,
+}
+
+pub type TransactionTable = HashMap<TransactionId, TransactionStatus>;
+
+pub fn is_visible(row_version: &Row, snapshot: &Snapshot, tx_table: &TransactionTable) -> bool {
+    let current_tx = snapshot.current_tx_id;
+
+    if current_tx == Some(row_version.created_tx) {
+        return row_version.deleted_tx != current_tx;
+    }
+
+    if !created_tx_visible(row_version.created_tx, snapshot, tx_table) {
+        return false;
+    }
+
+    match row_version.deleted_tx {
+        None => true,
+        Some(deleted_tx) if Some(deleted_tx) == current_tx => false,
+        Some(deleted_tx) => !committed_before_snapshot(deleted_tx, snapshot, tx_table),
+    }
+}
+
+fn created_tx_visible(
+    created_tx: TransactionId,
+    snapshot: &Snapshot,
+    tx_table: &TransactionTable,
+) -> bool {
+    committed_before_snapshot(created_tx, snapshot, tx_table)
+}
+
+fn committed_before_snapshot(
+    tx_id: TransactionId,
+    snapshot: &Snapshot,
+    tx_table: &TransactionTable,
+) -> bool {
+    tx_id == COMMITTED_BOOTSTRAP_TX
+        || (tx_id < snapshot.xmax
+            && !snapshot.active_tx_ids.binary_search(&tx_id).is_ok()
+            && tx_table.get(&tx_id) == Some(&TransactionStatus::Committed))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::row::RowData;
+
+    fn row(created_tx: TransactionId, deleted_tx: Option<TransactionId>) -> Row {
+        let mut row = Row::new(1, RowData(Vec::new()));
+        row.created_tx = created_tx;
+        row.deleted_tx = deleted_tx;
+        row
+    }
+
+    fn snapshot() -> Snapshot {
+        Snapshot::new_for_transaction(10, 20, vec![15])
+    }
+
+    #[test]
+    fn own_write_visible_unless_self_deleted() {
+        let tx_table = TransactionTable::new();
+        assert!(is_visible(&row(10, None), &snapshot(), &tx_table));
+        assert!(!is_visible(&row(10, Some(10)), &snapshot(), &tx_table));
+    }
+
+    #[test]
+    fn committed_creator_before_snapshot_is_visible() {
+        let mut tx_table = TransactionTable::new();
+        tx_table.insert(8, TransactionStatus::Committed);
+        assert!(is_visible(&row(8, None), &snapshot(), &tx_table));
+    }
+
+    #[test]
+    fn active_at_snapshot_creator_is_invisible() {
+        let mut tx_table = TransactionTable::new();
+        tx_table.insert(15, TransactionStatus::Committed);
+        assert!(!is_visible(&row(15, None), &snapshot(), &tx_table));
+    }
+
+    #[test]
+    fn uncommitted_delete_keeps_old_version_visible() {
+        let mut tx_table = TransactionTable::new();
+        tx_table.insert(8, TransactionStatus::Committed);
+        tx_table.insert(12, TransactionStatus::Active);
+        assert!(is_visible(&row(8, Some(12)), &snapshot(), &tx_table));
+    }
+
+    #[test]
+    fn committed_delete_before_snapshot_hides_old_version() {
+        let mut tx_table = TransactionTable::new();
+        tx_table.insert(8, TransactionStatus::Committed);
+        tx_table.insert(12, TransactionStatus::Committed);
+        assert!(!is_visible(&row(8, Some(12)), &snapshot(), &tx_table));
+    }
+}

--- a/src/transaction/state.rs
+++ b/src/transaction/state.rs
@@ -29,10 +29,27 @@ pub struct Snapshot {
     pub xmin: TransactionId,
     pub xmax: TransactionId,
     pub active_tx_ids: Vec<TransactionId>,
+    pub current_tx_id: Option<TransactionId>,
 }
 
 impl Snapshot {
-    pub fn new(xmax: TransactionId, mut active_tx_ids: Vec<TransactionId>) -> Self {
+    pub fn new(xmax: TransactionId, active_tx_ids: Vec<TransactionId>) -> Self {
+        Self::new_with_current(xmax, active_tx_ids, None)
+    }
+
+    pub fn new_for_transaction(
+        current_tx_id: TransactionId,
+        xmax: TransactionId,
+        active_tx_ids: Vec<TransactionId>,
+    ) -> Self {
+        Self::new_with_current(xmax, active_tx_ids, Some(current_tx_id))
+    }
+
+    fn new_with_current(
+        xmax: TransactionId,
+        mut active_tx_ids: Vec<TransactionId>,
+        current_tx_id: Option<TransactionId>,
+    ) -> Self {
         active_tx_ids.sort_unstable();
         active_tx_ids.dedup();
         let xmin = active_tx_ids.first().copied().unwrap_or(xmax);
@@ -41,6 +58,7 @@ impl Snapshot {
             xmin,
             xmax,
             active_tx_ids,
+            current_tx_id,
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Implement row-version visibility logic for MVCC using explicit rules for created/ deleted transaction visibility and own-transaction visibility. 
- Provide a small API surface so transaction-aware callers can obtain a snapshot that includes the current transaction id. 

### Description
- Add `src/transaction/mvcc.rs` with `TransactionStatus`, `TransactionTable` and `is_visible(row_version, snapshot, tx_table)` implementing the requested MVCC rules and unit tests. 
- Extend `Snapshot` with a `current_tx_id` field and add `Snapshot::new_for_transaction` (and a helper constructor) so snapshots can record the current transaction. 
- Expose a `Catalog::current_snapshot()` and `TransactionManager::current_snapshot()` for callers to obtain the current snapshot including the current transaction id. 
- Route B-Tree visibility checks through the new `is_visible` helper (bootstrap compatibility preserved) so storage-level filters use the centralized MVCC rules. 

### Testing
- Ran the full automated test suite with `cargo test`, including new `transaction::mvcc` unit tests; the test run completed successfully with all tests passing. 
- The added `mvcc` unit tests for `is_visible` passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fbd7915048333ab845bddb203f1e7)