### PR TITLE
Use MVCC-visible reads in runtime scans

### DIFF
--- a/src/execution/runtime.rs
+++ b/src/execution/runtime.rs
@@ -1,14 +1,14 @@
 use crate::catalog::Catalog;
 use crate::constraints::{
-    Constraint, default::DefaultConstraint, foreign_key::ForeignKeyConstraint,
-    not_null::NotNullConstraint, primary_key::PrimaryKeyConstraint,
+    default::DefaultConstraint, foreign_key::ForeignKeyConstraint, not_null::NotNullConstraint,
+    primary_key::PrimaryKeyConstraint, Constraint,
 };
 use crate::error::{DbError, DbResult};
 use crate::planner::aggregate;
-use crate::sql::ast::{Expr, Statement, expr_to_string};
+use crate::sql::ast::{expr_to_string, Expr, Statement};
 use crate::storage::btree::BTree;
 use crate::storage::row::{
-    COMMITTED_BOOTSTRAP_TX, ColumnType, ColumnValue, Row, RowData, build_row_data,
+    build_row_data, ColumnType, ColumnValue, Row, RowData, COMMITTED_BOOTSTRAP_TX,
 };
 use crate::transaction::Snapshot;
 use std::collections::HashMap;
@@ -511,6 +511,7 @@ pub fn execute_select_with_indexes(
     let table_info = catalog.get_table(table_name)?.clone();
     let root_page = table_info.root_page;
     let columns = table_info.columns.clone();
+    let snapshot = dml_snapshot(catalog);
 
     if let Some(Expr::Equals { left, right }) = selection.clone() {
         let (col_name, value) = if columns.iter().any(|(c, _)| c == &left) {
@@ -532,7 +533,7 @@ pub fn execute_select_with_indexes(
                                 if let ColumnValue::Integer(k) = val {
                                     let mut table_tree =
                                         BTree::open_root(&mut catalog.pager, root_page)?;
-                                    if let Some(r) = table_tree.find(*k)? {
+                                    if let Some(r) = table_tree.find_visible(*k, &snapshot)? {
                                         out.push(r);
                                     }
                                 }
@@ -547,8 +548,7 @@ pub fn execute_select_with_indexes(
     }
 
     let mut table_btree = BTree::open_root(&mut catalog.pager, root_page)?;
-    let mut cursor = table_btree.scan_all_rows();
-    while let Some(row) = cursor.next() {
+    for row in table_btree.scan_visible(&snapshot)? {
         if let Some(ref expr) = selection {
             let mut values = HashMap::new();
             for ((col, _), val) in columns.iter().zip(row.data.0.iter()) {
@@ -580,9 +580,9 @@ pub fn execute_multi_join(
     // base table scan
     {
         let base_info = catalog.get_table(&plan.base_table)?.clone();
+        let snapshot = dml_snapshot(catalog);
         let mut tree = BTree::open_root(&mut catalog.pager, base_info.root_page)?;
-        let mut cursor = tree.scan_all_rows();
-        while let Some(row) = cursor.next() {
+        for row in tree.scan_visible(&snapshot)? {
             let mut map = std::collections::HashMap::new();
             let alias = plan.base_alias.as_deref().unwrap_or(&plan.base_table);
             for ((c, _), v) in base_info.columns.iter().zip(row.data.0.iter()) {
@@ -599,11 +599,11 @@ pub fn execute_multi_join(
     for jc in &plan.joins {
         let alias = jc.alias.as_ref().unwrap_or(&jc.table);
         let info = catalog.get_table(&jc.table)?.clone();
+        let snapshot = dml_snapshot(catalog);
         let mut tree = BTree::open_root(&mut catalog.pager, info.root_page)?;
         let rows: Vec<_> = {
-            let mut curs = tree.scan_all_rows();
             let mut tmp = Vec::new();
-            while let Some(r) = curs.next() {
+            for r in tree.scan_visible(&snapshot)? {
                 let mut m = std::collections::HashMap::new();
                 for ((c, _), v) in info.columns.iter().zip(r.data.0.iter()) {
                     m.insert(format!("{alias}.{c}"), v.clone());

--- a/tests/runtime_mvcc.rs
+++ b/tests/runtime_mvcc.rs
@@ -1,0 +1,143 @@
+use aerodb::{
+    engine::Engine,
+    execution::runtime::{execute_group_query, execute_multi_join, execute_select_with_indexes},
+    sql::{ast::Statement, parser::parse_statement},
+};
+use std::fs;
+
+fn setup_engine(filename: &str) -> Engine {
+    let _ = fs::remove_file(filename);
+    let _ = fs::remove_file(format!("{}.wal", filename));
+    Engine::new(filename)
+}
+
+fn open_engine(filename: &str) -> Engine {
+    Engine::new(filename)
+}
+
+#[test]
+fn indexed_select_obeys_mvcc_visibility_across_transaction_lifecycle() {
+    let filename = "runtime_mvcc_indexed_select.db";
+    let mut writer = setup_engine(filename);
+    writer
+        .execute(parse_statement("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)").unwrap())
+        .unwrap();
+    writer
+        .execute(parse_statement("CREATE INDEX idx_t_name ON t (name)").unwrap())
+        .unwrap();
+    writer.execute(parse_statement("BEGIN").unwrap()).unwrap();
+    writer
+        .execute(parse_statement("INSERT INTO t VALUES (1, 'alice')").unwrap())
+        .unwrap();
+
+    let predicate = parse_statement("SELECT * FROM t WHERE name = 'alice'").unwrap();
+    let selection = match predicate {
+        Statement::Select {
+            where_predicate, ..
+        } => where_predicate,
+        _ => unreachable!(),
+    };
+
+    let mut same_tx_rows = Vec::new();
+    execute_select_with_indexes(
+        &mut writer.catalog,
+        "t",
+        selection.clone(),
+        &mut same_tx_rows,
+    )
+    .unwrap();
+    assert_eq!(same_tx_rows.len(), 1);
+
+    let mut other_snapshot = open_engine(filename);
+    other_snapshot
+        .execute(parse_statement("BEGIN").unwrap())
+        .unwrap();
+    let mut other_rows = Vec::new();
+    execute_select_with_indexes(
+        &mut other_snapshot.catalog,
+        "t",
+        selection.clone(),
+        &mut other_rows,
+    )
+    .unwrap();
+    assert!(other_rows.is_empty());
+
+    writer.execute(parse_statement("COMMIT").unwrap()).unwrap();
+    drop(writer);
+    let mut after_commit = open_engine(filename);
+    let mut committed_rows = Vec::new();
+    execute_select_with_indexes(
+        &mut after_commit.catalog,
+        "t",
+        selection,
+        &mut committed_rows,
+    )
+    .unwrap();
+    assert_eq!(committed_rows.len(), 1);
+}
+
+#[test]
+fn joins_and_aggregates_read_visible_rows_inside_transaction() {
+    let filename = "runtime_mvcc_join_group.db";
+    let mut engine = setup_engine(filename);
+    engine
+        .execute(parse_statement("CREATE TABLE a (id INTEGER PRIMARY KEY, v TEXT)").unwrap())
+        .unwrap();
+    engine
+        .execute(parse_statement("CREATE TABLE b (id INTEGER PRIMARY KEY, a_id INTEGER)").unwrap())
+        .unwrap();
+    engine.execute(parse_statement("BEGIN").unwrap()).unwrap();
+    engine
+        .execute(parse_statement("INSERT INTO a VALUES (1, 'av1')").unwrap())
+        .unwrap();
+    engine
+        .execute(parse_statement("INSERT INTO b VALUES (1, 1)").unwrap())
+        .unwrap();
+
+    let stmt = parse_statement("SELECT a.v, b.id FROM a JOIN b ON a.id = b.a_id").unwrap();
+    let mut join_rows = Vec::new();
+    if let Statement::Select {
+        columns,
+        from,
+        joins,
+        where_predicate,
+        ..
+    } = stmt
+    {
+        let base_table = match from.first().unwrap() {
+            aerodb::sql::ast::TableRef::Named { name, .. } => name.clone(),
+            _ => unreachable!(),
+        };
+        let plan = aerodb::execution::plan::MultiJoinPlan {
+            base_table,
+            base_alias: None,
+            joins,
+            projections: columns,
+            where_predicate,
+        };
+        execute_multi_join(&plan, &mut engine.catalog, &mut join_rows).unwrap();
+    }
+    assert_eq!(join_rows, vec![vec!["av1".to_string(), "1".to_string()]]);
+
+    let group_stmt = parse_statement("SELECT COUNT(*) FROM a").unwrap();
+    let mut aggregate_rows = Vec::new();
+    if let Statement::Select {
+        columns,
+        where_predicate,
+        ..
+    } = group_stmt
+    {
+        execute_group_query(
+            &mut engine.catalog,
+            "a",
+            &columns,
+            None,
+            None,
+            where_predicate,
+            &mut aggregate_rows,
+            None,
+        )
+        .unwrap();
+    }
+    assert_eq!(aggregate_rows, vec![vec!["1".to_string()]]);
+}


### PR DESCRIPTION
### Motivation
- Ensure runtime SELECTs, joins and aggregates only observe MVCC-visible row versions so transaction-local writes are seen by the writer and hidden from other snapshots. 
- Use the engine snapshot logic consistently in index lookups and full table scans to implement correct snapshot isolation for reads.

### Description
- In `execute_select_with_indexes` capture `snapshot = dml_snapshot(catalog)` and use `table_tree.find_visible(key, &snapshot)` for index lookups and `scan_visible(&snapshot)` instead of `scan_all_rows()` for full-table scans. 
- In `execute_multi_join` use `dml_snapshot(catalog)` and iterate `BTree::scan_visible(&snapshot)?` for both the base table and joined tables so joins only combine visible row versions. 
- `execute_group_query` now receives its input via `execute_select_with_indexes`, so group/aggregate inputs become the MVCC-visible row set as a result of the above change. 
- Added `tests/runtime_mvcc.rs` with coverage for same-transaction visibility, isolation from another transaction snapshot, post-commit visibility on a new snapshot, and that joins/aggregates use visible rows.

### Testing
- Ran `cargo test --test runtime_mvcc` and the two new MVCC runtime tests passed. 
- Ran the full suite with `cargo test` and all tests completed successfully (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fc16b100c8333b1f13a90a2eee98b)