### PR TITLE
Switch WAL to record-oriented format

### DIFF
--- a/src/transaction/wal.rs
+++ b/src/transaction/wal.rs
@@ -1,15 +1,36 @@
 use std::fs::{File, OpenOptions};
-use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::io::{self, ErrorKind, Read, Seek, SeekFrom, Write};
 
 use crate::storage::page::PAGE_SIZE;
 
 use super::{CommitTimestamp, TransactionId, TransactionStatus, TransactionTable};
 
-const CHECKPOINT_RECORD: u32 = u32::MAX;
-const TX_STATUS_RECORD: u32 = u32::MAX - 1;
-const TX_STATUS_ACTIVE: u8 = 0;
-const TX_STATUS_COMMITTED: u8 = 1;
-const TX_STATUS_ABORTED: u8 = 2;
+const WAL_MAGIC: &[u8; 8] = b"AEROWAL2";
+const PAGE_IMAGE_TAG: u8 = 1;
+const TX_BEGIN_TAG: u8 = 2;
+const TX_COMMIT_TAG: u8 = 3;
+const TX_ABORT_TAG: u8 = 4;
+const CHECKPOINT_TAG: u8 = 5;
+
+/// Record-oriented WAL entry format.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WalRecord {
+    PageImage {
+        page_num: u32,
+        data: Box<[u8; PAGE_SIZE]>,
+    },
+    TxBegin {
+        tx_id: TransactionId,
+    },
+    TxCommit {
+        tx_id: TransactionId,
+        commit_ts: CommitTimestamp,
+    },
+    TxAbort {
+        tx_id: TransactionId,
+    },
+    Checkpoint,
+}
 
 pub struct Wal {
     file: File,
@@ -23,60 +44,163 @@ impl Wal {
             .create(true)
             .open(path)?;
         let tx_table = Wal::recover_internal(&mut file, db_file)?;
+        Wal::initialize_empty_log(&mut file)?;
         Ok((Wal { file }, tx_table))
     }
 
     fn recover_internal(wal: &mut File, db: &mut File) -> io::Result<TransactionTable> {
         wal.seek(SeekFrom::Start(0))?;
+        if !Wal::read_or_initialize_header(wal)? {
+            return Ok(TransactionTable::new());
+        }
+
         let mut tx_table = TransactionTable::new();
-        let mut record_buf = [0u8; 4];
-        loop {
-            if wal.read_exact(&mut record_buf).is_err() {
-                break;
-            }
-            match u32::from_le_bytes(record_buf) {
-                CHECKPOINT_RECORD => break,
-                TX_STATUS_RECORD => {
-                    let mut tx_id_buf = [0u8; 8];
-                    let mut status_buf = [0u8; 1];
-                    let mut commit_ts_buf = [0u8; 8];
-                    wal.read_exact(&mut tx_id_buf)?;
-                    wal.read_exact(&mut status_buf)?;
-                    wal.read_exact(&mut commit_ts_buf)?;
-                    let tx_id = TransactionId::from_le_bytes(tx_id_buf);
-                    let commit_ts = CommitTimestamp::from_le_bytes(commit_ts_buf);
-                    let status = match status_buf[0] {
-                        TX_STATUS_ACTIVE => TransactionStatus::Active,
-                        TX_STATUS_COMMITTED => TransactionStatus::Committed(commit_ts),
-                        TX_STATUS_ABORTED => TransactionStatus::Aborted,
-                        other => {
-                            return Err(io::Error::new(
-                                io::ErrorKind::InvalidData,
-                                format!("unknown WAL transaction status tag {other}"),
-                            ));
-                        }
-                    };
-                    tx_table.insert(tx_id, status);
-                }
-                page_num => {
-                    let mut data = [0u8; PAGE_SIZE];
-                    wal.read_exact(&mut data)?;
+        while let Some(record) = Wal::read_record(wal)? {
+            match record {
+                WalRecord::PageImage { page_num, data } => {
                     db.seek(SeekFrom::Start(page_num as u64 * PAGE_SIZE as u64))?;
-                    db.write_all(&data)?;
+                    db.write_all(&*data)?;
                 }
+                WalRecord::TxBegin { tx_id } => {
+                    tx_table.insert(tx_id, TransactionStatus::Active);
+                }
+                WalRecord::TxCommit { tx_id, commit_ts } => {
+                    tx_table.insert(tx_id, TransactionStatus::Committed(commit_ts));
+                }
+                WalRecord::TxAbort { tx_id } => {
+                    tx_table.insert(tx_id, TransactionStatus::Aborted);
+                }
+                WalRecord::Checkpoint => {}
             }
         }
+
+        for status in tx_table.values_mut() {
+            if matches!(status, TransactionStatus::Active) {
+                *status = TransactionStatus::Aborted;
+            }
+        }
+
         wal.set_len(0)?;
         wal.sync_all()?;
         Ok(tx_table)
     }
 
-    pub fn append_page(&mut self, page_num: u32, data: &[u8; PAGE_SIZE]) -> io::Result<()> {
+    /// Returns true when the WAL uses the current record format. Older page-first
+    /// WALs did not contain a magic header; they are treated as an incompatible
+    /// legacy format and truncated for a clean start instead of being replayed as
+    /// ambiguous records.
+    fn read_or_initialize_header(wal: &mut File) -> io::Result<bool> {
+        let len = wal.metadata()?.len();
+        if len == 0 {
+            wal.write_all(WAL_MAGIC)?;
+            wal.sync_all()?;
+            return Ok(true);
+        }
+
+        let mut magic = [0u8; WAL_MAGIC.len()];
+        match wal.read_exact(&mut magic) {
+            Ok(()) if &magic == WAL_MAGIC => Ok(true),
+            Ok(()) | Err(_) => {
+                wal.set_len(0)?;
+                wal.seek(SeekFrom::Start(0))?;
+                wal.write_all(WAL_MAGIC)?;
+                wal.sync_all()?;
+                Ok(false)
+            }
+        }
+    }
+
+    fn initialize_empty_log(wal: &mut File) -> io::Result<()> {
+        if wal.metadata()?.len() == 0 {
+            wal.seek(SeekFrom::Start(0))?;
+            wal.write_all(WAL_MAGIC)?;
+            wal.sync_all()?;
+        }
+        Ok(())
+    }
+
+    fn read_record(wal: &mut File) -> io::Result<Option<WalRecord>> {
+        let mut tag = [0u8; 1];
+        match wal.read_exact(&mut tag) {
+            Ok(()) => {}
+            Err(err) if err.kind() == ErrorKind::UnexpectedEof => return Ok(None),
+            Err(err) => return Err(err),
+        }
+
+        let record = match tag[0] {
+            PAGE_IMAGE_TAG => {
+                let page_num = Wal::read_u32(wal)?;
+                let mut data = Box::new([0u8; PAGE_SIZE]);
+                wal.read_exact(data.as_mut())?;
+                WalRecord::PageImage { page_num, data }
+            }
+            TX_BEGIN_TAG => WalRecord::TxBegin {
+                tx_id: Wal::read_u64(wal)?,
+            },
+            TX_COMMIT_TAG => WalRecord::TxCommit {
+                tx_id: Wal::read_u64(wal)?,
+                commit_ts: Wal::read_u64(wal)?,
+            },
+            TX_ABORT_TAG => WalRecord::TxAbort {
+                tx_id: Wal::read_u64(wal)?,
+            },
+            CHECKPOINT_TAG => WalRecord::Checkpoint,
+            other => {
+                return Err(io::Error::new(
+                    ErrorKind::InvalidData,
+                    format!("unknown WAL record tag {other}"),
+                ));
+            }
+        };
+        Ok(Some(record))
+    }
+
+    fn read_u32(wal: &mut File) -> io::Result<u32> {
+        let mut buf = [0u8; 4];
+        wal.read_exact(&mut buf)?;
+        Ok(u32::from_le_bytes(buf))
+    }
+
+    fn read_u64(wal: &mut File) -> io::Result<u64> {
+        let mut buf = [0u8; 8];
+        wal.read_exact(&mut buf)?;
+        Ok(u64::from_le_bytes(buf))
+    }
+
+    fn append_record(&mut self, record: WalRecord) -> io::Result<()> {
         self.file.seek(SeekFrom::End(0))?;
-        self.file.write_all(&page_num.to_le_bytes())?;
-        self.file.write_all(data)?;
+        match record {
+            WalRecord::PageImage { page_num, data } => {
+                self.file.write_all(&[PAGE_IMAGE_TAG])?;
+                self.file.write_all(&page_num.to_le_bytes())?;
+                self.file.write_all(&*data)?;
+            }
+            WalRecord::TxBegin { tx_id } => {
+                self.file.write_all(&[TX_BEGIN_TAG])?;
+                self.file.write_all(&tx_id.to_le_bytes())?;
+            }
+            WalRecord::TxCommit { tx_id, commit_ts } => {
+                self.file.write_all(&[TX_COMMIT_TAG])?;
+                self.file.write_all(&tx_id.to_le_bytes())?;
+                self.file.write_all(&commit_ts.to_le_bytes())?;
+            }
+            WalRecord::TxAbort { tx_id } => {
+                self.file.write_all(&[TX_ABORT_TAG])?;
+                self.file.write_all(&tx_id.to_le_bytes())?;
+            }
+            WalRecord::Checkpoint => {
+                self.file.write_all(&[CHECKPOINT_TAG])?;
+            }
+        }
         self.file.sync_all()?;
         Ok(())
+    }
+
+    pub fn append_page(&mut self, page_num: u32, data: &[u8; PAGE_SIZE]) -> io::Result<()> {
+        self.append_record(WalRecord::PageImage {
+            page_num,
+            data: Box::new(*data),
+        })
     }
 
     pub fn append_tx_status(
@@ -84,29 +208,23 @@ impl Wal {
         tx_id: TransactionId,
         status: TransactionStatus,
     ) -> io::Result<()> {
-        let (status_tag, commit_ts) = match status {
-            TransactionStatus::Active => (TX_STATUS_ACTIVE, 0),
-            TransactionStatus::Committed(commit_ts) => (TX_STATUS_COMMITTED, commit_ts),
-            TransactionStatus::Aborted => (TX_STATUS_ABORTED, 0),
-        };
-        self.file.seek(SeekFrom::End(0))?;
-        self.file.write_all(&TX_STATUS_RECORD.to_le_bytes())?;
-        self.file.write_all(&tx_id.to_le_bytes())?;
-        self.file.write_all(&[status_tag])?;
-        self.file.write_all(&commit_ts.to_le_bytes())?;
-        self.file.sync_all()?;
-        Ok(())
+        match status {
+            TransactionStatus::Active => self.append_record(WalRecord::TxBegin { tx_id }),
+            TransactionStatus::Committed(commit_ts) => {
+                self.append_record(WalRecord::TxCommit { tx_id, commit_ts })
+            }
+            TransactionStatus::Aborted => self.append_record(WalRecord::TxAbort { tx_id }),
+        }
     }
 
     pub fn append_checkpoint(&mut self) -> io::Result<()> {
-        self.file.seek(SeekFrom::End(0))?;
-        self.file.write_all(&CHECKPOINT_RECORD.to_le_bytes())?;
-        self.file.sync_all()?;
-        Ok(())
+        self.append_record(WalRecord::Checkpoint)
     }
 
     pub fn truncate(&mut self) -> io::Result<()> {
         self.file.set_len(0)?;
+        self.file.seek(SeekFrom::Start(0))?;
+        self.file.write_all(WAL_MAGIC)?;
         self.file.sync_all()?;
         Ok(())
     }


### PR DESCRIPTION
### Motivation
- Replace the previous page-first WAL layout with a typed, record-oriented WAL so records are explicit and recovery can reconstruct transaction state reliably.
- Support explicit transaction lifecycle records and checkpoints so recovery can apply page images deterministically and decide transaction outcomes.
- Provide a safe migration/clean-start strategy for legacy WAL files that do not match the new record format.

### Description
- Introduce a `WalRecord` enum with variants `PageImage { page_num, data }`, `TxBegin { tx_id }`, `TxCommit { tx_id, commit_ts }`, `TxAbort { tx_id }`, and `Checkpoint` and add tag constants and a `WAL_MAGIC` header for the new format.
- Rework recovery in `recover_internal` to scan records from the start, apply `PageImage` entries to the DB file, rebuild the `TransactionTable` from `TxBegin`/`TxCommit`/`TxAbort` records, and mark any remaining `Active` transactions as `Aborted`.
- Add robust record I/O helpers: `read_record`, `read_u32`, `read_u64`, `append_record`, plus `append_page` reimplemented to emit `PageImage` records and `append_tx_status` to emit `TxBegin`/`TxCommit`/`TxAbort` records, and `append_checkpoint` to emit `Checkpoint`.
- Implement a migration/clean-start policy: WALs without the `WAL_MAGIC` header are treated as legacy/incompatible, truncated and reinitialized with the new header to avoid ambiguous replay.

### Testing
- Ran the full test suite with `cargo test` and all tests passed (unit and integration tests completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50aba30b008333a53d1675506d1091)