### PR TITLE
Add snapshot-isolation write-conflict detection and isolation-level plumbing

### DIFF
--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -3,7 +3,7 @@ use crate::storage::btree::BTree;
 use crate::storage::page::PAGE_SIZE;
 use crate::storage::pager::Pager;
 use crate::storage::row::{ColumnType, ColumnValue, Row, RowData};
-use crate::transaction::{Snapshot, TransactionId};
+use crate::transaction::{IsolationLevel, Snapshot, TransactionId};
 use log::debug;
 use std::collections::HashMap;
 use std::io;
@@ -230,6 +230,14 @@ impl Catalog {
     }
 
     pub fn begin_transaction(&mut self, name: Option<String>) -> io::Result<()> {
+        self.begin_transaction_with_isolation(name, IsolationLevel::default())
+    }
+
+    pub fn begin_transaction_with_isolation(
+        &mut self,
+        name: Option<String>,
+        isolation_level: IsolationLevel,
+    ) -> io::Result<()> {
         if self.transaction_active() {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
@@ -245,11 +253,11 @@ impl Catalog {
         );
 
         debug!(
-            "Transaction started with id: {}, snapshot: {:?}, name: {:?}",
-            transaction_id, snapshot, name
+            "Transaction started with id: {}, snapshot: {:?}, name: {:?}, isolation: {:?}",
+            transaction_id, snapshot, name, isolation_level
         );
         self.pager
-            .begin_transaction(transaction_id, snapshot, name)?;
+            .begin_transaction(transaction_id, snapshot, name, isolation_level)?;
         self.active_tx_ids.push(transaction_id);
         Ok(())
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
-use thiserror::Error;
 use std::io;
+use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum DbError {
@@ -23,6 +23,8 @@ pub enum DbError {
     GroupByMismatch(String),
     #[error("{0} not found")]
     NotFound(String),
+    #[error("write conflict on logical key {0}")]
+    WriteConflict(i32),
     #[error(transparent)]
     Io(#[from] io::Error),
 }

--- a/src/execution/runtime.rs
+++ b/src/execution/runtime.rs
@@ -61,6 +61,18 @@ fn current_tx_id(catalog: &Catalog) -> u64 {
         .unwrap_or(COMMITTED_BOOTSTRAP_TX)
 }
 
+fn ensure_no_write_conflict(
+    table_btree: &mut BTree<'_>,
+    key: i32,
+    visible_created_tx: u64,
+    snapshot: &Snapshot,
+) -> DbResult<()> {
+    if table_btree.has_write_conflict(key, visible_created_tx, snapshot)? {
+        return Err(DbError::WriteConflict(key));
+    }
+    Ok(())
+}
+
 pub fn execute_delete(
     catalog: &mut Catalog,
     table_name: &str,
@@ -108,6 +120,7 @@ pub fn execute_delete(
             let tx_id = current_tx_id(catalog);
             let mut table_btree = BTree::open_root(&mut catalog.pager, root_page)?;
             for r in &rows_to_delete {
+                ensure_no_write_conflict(&mut table_btree, r.key, r.created_tx, &snapshot)?;
                 table_btree.mark_deleted_visible(r.key, &snapshot, tx_id)?;
             }
             let new_root = table_btree.root_page();
@@ -339,6 +352,12 @@ pub fn execute_update(
             let tx_id = current_tx_id(catalog);
             let mut table_btree = BTree::open_root(&mut catalog.pager, root_page)?;
             for op in &ops {
+                ensure_no_write_conflict(
+                    &mut table_btree,
+                    op.old_key,
+                    op.old_created_tx,
+                    &snapshot,
+                )?;
                 table_btree.mark_deleted_visible(op.old_key, &snapshot, tx_id)?;
                 let mut new_row = Row::new(op.new_key, op.new_data.clone());
                 new_row.created_tx = tx_id;

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,7 @@ fn main() -> io::Result<()> {
                         DbError::NotFound(m) => println!("Error: {}", m),
                         DbError::NullViolation(c) => println!("Error: column '{}' cannot be NULL", c),
                         DbError::ForeignKeyViolation(m) => println!("Error: {}", m),
+                        DbError::WriteConflict(k) => println!("Error: write conflict on logical key {}", k),
                         DbError::Io(err) => println!("IO error: {}", err),
                     }
                 }

--- a/src/storage/btree.rs
+++ b/src/storage/btree.rs
@@ -101,6 +101,47 @@ impl<'a> BTree<'a> {
         Ok(visible)
     }
 
+    /// Return true when the logical key visible in `snapshot` has been changed
+    /// by another transaction that was not visible to that snapshot. UPDATE and
+    /// DELETE use this to provide snapshot-isolation write/write conflict
+    /// detection before they mark the visible version as deleted.
+    pub fn has_write_conflict(
+        &mut self,
+        key: i32,
+        visible_created_tx: TransactionId,
+        snapshot: &Snapshot,
+    ) -> io::Result<bool> {
+        let current_tx = snapshot.current_tx_id;
+        for row in self.collect_all_rows()? {
+            if row.key != key {
+                continue;
+            }
+
+            if row.created_tx != visible_created_tx
+                && Self::changed_after_snapshot(row.created_tx, snapshot)
+                && Some(row.created_tx) != current_tx
+            {
+                return Ok(true);
+            }
+
+            if row.created_tx == visible_created_tx {
+                if let Some(deleted_tx) = row.deleted_tx {
+                    if Self::changed_after_snapshot(deleted_tx, snapshot)
+                        && Some(deleted_tx) != current_tx
+                    {
+                        return Ok(true);
+                    }
+                }
+            }
+        }
+
+        Ok(false)
+    }
+
+    fn changed_after_snapshot(tx_id: TransactionId, snapshot: &Snapshot) -> bool {
+        tx_id >= snapshot.xmax || snapshot.active_tx_ids.binary_search(&tx_id).is_ok()
+    }
+
     fn find_latest_logical(&mut self, key: i32) -> io::Result<Option<Row>> {
         let snapshot = Snapshot::new(TransactionId::MAX, Vec::new());
         self.find_visible(key, &snapshot)
@@ -1102,5 +1143,56 @@ impl<'b> Iterator for RowCursor<'b> {
             self.offset = HEADER_SIZE;
             self.rows_in_page = 0;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    fn row_with_tx(key: i32, value: &str, created_tx: TransactionId) -> Row {
+        let mut row = Row::new(
+            key,
+            RowData(vec![crate::storage::row::ColumnValue::Text(value.into())]),
+        );
+        row.created_tx = created_tx;
+        row
+    }
+
+    #[test]
+    fn write_conflict_detects_version_created_after_snapshot() {
+        let file = NamedTempFile::new().unwrap();
+        let mut pager = Pager::new(file.path().to_str().unwrap()).unwrap();
+        let mut btree = BTree::new(&mut pager).unwrap();
+        btree.insert_version(row_with_tx(1, "before", 1)).unwrap();
+        let snapshot = Snapshot::new_for_transaction(2, 3, vec![]);
+        let visible = btree.find_visible(1, &snapshot).unwrap().unwrap();
+
+        btree.insert_version(row_with_tx(1, "after", 4)).unwrap();
+
+        assert!(
+            btree
+                .has_write_conflict(1, visible.created_tx, &snapshot)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn write_conflict_detects_delete_after_snapshot() {
+        let file = NamedTempFile::new().unwrap();
+        let mut pager = Pager::new(file.path().to_str().unwrap()).unwrap();
+        let mut btree = BTree::new(&mut pager).unwrap();
+        btree.insert_version(row_with_tx(1, "before", 1)).unwrap();
+        let snapshot = Snapshot::new_for_transaction(2, 3, vec![]);
+        let visible = btree.find_visible(1, &snapshot).unwrap().unwrap();
+
+        assert!(btree.mark_deleted_visible(1, &snapshot, 4).unwrap());
+
+        assert!(
+            btree
+                .has_write_conflict(1, visible.created_tx, &snapshot)
+                .unwrap()
+        );
     }
 }

--- a/src/storage/pager.rs
+++ b/src/storage/pager.rs
@@ -1,6 +1,7 @@
 use crate::storage::{dirty_pages::DirtyPageSet, page::PAGE_SIZE};
 use crate::transaction::{
-    wal::Wal, Snapshot, TransactionId, TransactionState, TransactionStatus, TransactionTable,
+    IsolationLevel, Snapshot, TransactionId, TransactionState, TransactionStatus, TransactionTable,
+    wal::Wal,
 };
 use std::fs::{File, OpenOptions};
 use std::io::{self, Read, Seek, SeekFrom, Write};
@@ -171,8 +172,9 @@ impl Pager {
         id: TransactionId,
         snapshot: Snapshot,
         name: Option<String>,
+        isolation_level: IsolationLevel,
     ) -> io::Result<()> {
-        self.transaction.begin(id, snapshot, name);
+        self.transaction.begin(id, snapshot, name, isolation_level);
         self.tx_table.insert(id, TransactionStatus::Active);
         self.wal.append_tx_status(id, TransactionStatus::Active)?;
         self.dirty_pages.clear();
@@ -260,7 +262,12 @@ mod tests {
         {
             let mut pager = Pager::new(path.to_str().unwrap()).unwrap();
             pager
-                .begin_transaction(7, Snapshot::new_for_transaction(7, 8, vec![]), None)
+                .begin_transaction(
+                    7,
+                    Snapshot::new_for_transaction(7, 8, vec![]),
+                    None,
+                    IsolationLevel::Snapshot,
+                )
                 .unwrap();
             pager.rollback_transaction().unwrap();
         }

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -9,5 +9,5 @@ mod state;
 pub use classifier::statement_requires_transaction;
 pub use manager::TransactionManager;
 pub use mvcc::is_visible;
-pub use state::{Snapshot, TransactionId, TransactionMode, TransactionState};
+pub use state::{IsolationLevel, Snapshot, TransactionId, TransactionMode, TransactionState};
 pub use tx_table::{CommitTimestamp, TransactionStatus, TransactionTable};

--- a/src/transaction/state.rs
+++ b/src/transaction/state.rs
@@ -23,6 +23,21 @@ impl Default for TransactionMode {
 /// added later through WAL/metastore integration.
 pub type TransactionId = u64;
 
+/// SQL transaction isolation levels. The parser does not expose `SET TRANSACTION
+/// ISOLATION LEVEL` yet, but keeping the isolation decision explicit here lets
+/// that syntax select a policy without reshaping transaction state later.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IsolationLevel {
+    /// One snapshot is captured at BEGIN and reused for the whole transaction.
+    Snapshot,
+}
+
+impl Default for IsolationLevel {
+    fn default() -> Self {
+        Self::Snapshot
+    }
+}
+
 /// MVCC snapshot captured when a transaction starts.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Snapshot {
@@ -72,6 +87,7 @@ pub struct TransactionState {
     id: Option<TransactionId>,
     snapshot: Option<Snapshot>,
     name: Option<String>,
+    isolation_level: IsolationLevel,
 }
 
 impl TransactionState {
@@ -79,11 +95,18 @@ impl TransactionState {
         self.active
     }
 
-    pub fn begin(&mut self, id: TransactionId, snapshot: Snapshot, name: Option<String>) {
+    pub fn begin(
+        &mut self,
+        id: TransactionId,
+        snapshot: Snapshot,
+        name: Option<String>,
+        isolation_level: IsolationLevel,
+    ) {
         self.active = true;
         self.id = Some(id);
         self.snapshot = Some(snapshot);
         self.name = name;
+        self.isolation_level = isolation_level;
     }
 
     pub fn finish(&mut self) {
@@ -91,6 +114,7 @@ impl TransactionState {
         self.id = None;
         self.snapshot = None;
         self.name = None;
+        self.isolation_level = IsolationLevel::default();
     }
 
     pub fn name(&self) -> Option<&str> {
@@ -104,6 +128,10 @@ impl TransactionState {
     pub fn snapshot(&self) -> Option<&Snapshot> {
         self.snapshot.as_ref()
     }
+
+    pub fn isolation_level(&self) -> IsolationLevel {
+        self.isolation_level
+    }
 }
 
 #[cfg(test)]
@@ -116,7 +144,12 @@ mod tests {
         assert!(!state.is_active());
 
         let snapshot = Snapshot::new(2, vec![1]);
-        state.begin(2, snapshot.clone(), Some("tx".to_string()));
+        state.begin(
+            2,
+            snapshot.clone(),
+            Some("tx".to_string()),
+            IsolationLevel::Snapshot,
+        );
         assert!(state.is_active());
         assert_eq!(state.id(), Some(2));
         assert_eq!(state.snapshot(), Some(&snapshot));


### PR DESCRIPTION
### Motivation
- Make explicit transaction semantics ready for snapshot isolation so a `BEGIN` transaction captures a snapshot that is reused for the transaction while implicit statements keep per-statement snapshots and auto-commit behavior. 
- Detect write/write conflicts at the SQL execution layer so `UPDATE`/`DELETE` fail when another committed transaction modified the same logical key after the statement snapshot. 
- Provide a discriminated place to expose `SET TRANSACTION ISOLATION LEVEL` in the future by adding an isolation enum. 

### Description
- Add `IsolationLevel` enum and thread it into pager/catalog/transaction state, including a new `begin_transaction_with_isolation` API and storing the selected isolation level in `TransactionState` (`src/transaction/state.rs`, `src/catalog/mod.rs`, `src/storage/pager.rs`).
- Implement B-Tree write-conflict detection via `BTree::has_write_conflict` which checks for newer versions or delete markers that changed after a snapshot (`src/storage/btree.rs`).
- Wire runtime checks into DML execution by calling `ensure_no_write_conflict` before marking visible versions deleted in `execute_delete` and `execute_update`, returning a `DbError::WriteConflict` on conflict (`src/execution/runtime.rs`).
- Add `DbError::WriteConflict(i32)` and display handling in the REPL so conflicts surface as user-facing errors (`src/error.rs`, `src/main.rs`).
- Add unit tests covering conflicts caused by a newer version and by a delete that occurs after the statement snapshot (`src/storage/btree.rs` test module).

### Testing
- Ran automated test suite with `cargo test`, and all tests completed successfully; the added write-conflict unit tests passed. 
- Verified the new code compiles and the REPL error path prints `write conflict on logical key <k>` when a `WriteConflict` is returned.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50b474b0d88333b42a222fd1495b7f)