### PR TITLE
Add explicit MVCC vacuum maintenance

### DIFF
--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -3,6 +3,7 @@ use crate::storage::btree::BTree;
 use crate::storage::page::PAGE_SIZE;
 use crate::storage::pager::Pager;
 use crate::storage::row::{ColumnType, ColumnValue, Row, RowData};
+use crate::storage::vacuum::VacuumReport;
 use crate::transaction::{IsolationLevel, Snapshot, TransactionId};
 use log::debug;
 use std::collections::HashMap;
@@ -299,6 +300,19 @@ impl Catalog {
 
     pub fn active_transaction_ids(&self) -> &[TransactionId] {
         &self.active_tx_ids
+    }
+
+    /// Oldest snapshot boundary that can still observe deleted versions.
+    ///
+    /// When there are no active transactions, the next transaction id is the
+    /// safe cutoff; otherwise the oldest active transaction id protects all
+    /// versions deleted by that transaction or newer transactions.
+    pub fn global_xmin(&self) -> TransactionId {
+        self.active_tx_ids
+            .iter()
+            .copied()
+            .min()
+            .unwrap_or(self.next_transaction_id)
     }
 
     fn allocate_transaction_id(&mut self) -> TransactionId {
@@ -675,6 +689,88 @@ impl Catalog {
 
     pub fn all_indexes(&self) -> Vec<IndexInfo> {
         self.indexes.values().cloned().collect()
+    }
+
+    /// Explicit internal maintenance API for physically pruning obsolete MVCC
+    /// versions from one table and lazily rebuilding that table's indexes to
+    /// remove stale index candidates left behind by UPDATE/DELETE.
+    pub fn vacuum_table(&mut self, table_name: &str) -> io::Result<VacuumReport> {
+        let table = self.get_table(table_name)?.clone();
+        let global_xmin = self.global_xmin();
+        let tx_table = self.pager.transaction_table().clone();
+
+        let versions_removed = {
+            let mut table_tree = BTree::open_root(&mut self.pager, table.root_page)?;
+            table_tree.vacuum_deleted_versions(global_xmin, &tx_table)?
+        };
+
+        let indexes_cleaned = if versions_removed > 0 {
+            self.rebuild_indexes_for_table(table_name)?
+        } else {
+            0
+        };
+        Ok(VacuumReport {
+            versions_removed,
+            indexes_cleaned,
+        })
+    }
+
+    fn rebuild_indexes_for_table(&mut self, table_name: &str) -> io::Result<usize> {
+        let table = self.get_table(table_name)?.clone();
+        let index_names: Vec<String> = self
+            .indexes
+            .values()
+            .filter(|index| index.table_name == table_name)
+            .map(|index| index.name.clone())
+            .collect();
+        let mut rebuilt = 0;
+
+        for index_name in index_names {
+            let index = self.indexes.get(&index_name).cloned().ok_or_else(|| {
+                io::Error::new(io::ErrorKind::NotFound, "index disappeared during vacuum")
+            })?;
+            let col_idx = table
+                .columns
+                .iter()
+                .position(|(column, _)| column == &index.column_name)
+                .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "index column not found"))?;
+
+            let mut rows = Vec::new();
+            {
+                let mut table_tree = BTree::open_root(&mut self.pager, table.root_page)?;
+                let mut cursor = table_tree.scan_all_rows();
+                while let Some(row) = cursor.next() {
+                    rows.push(row);
+                }
+            }
+
+            let mut new_root = self.pager.allocate_page()?;
+            {
+                let page = self.pager.get_page(new_root)?;
+                crate::storage::page::set_node_type(
+                    &mut page.data,
+                    crate::storage::page::NODE_LEAF,
+                );
+                crate::storage::page::set_is_root(&mut page.data, true);
+                crate::storage::page::set_parent(&mut page.data, 0);
+                crate::storage::page::set_cell_count(&mut page.data, 0);
+                self.pager.flush_page(new_root)?;
+            }
+            {
+                let mut index_tree = BTree::open_root(&mut self.pager, new_root)?;
+                for row in rows {
+                    if let Some(value) = row.data.0.get(col_idx).cloned() {
+                        new_root = Catalog::insert_index_value(&mut index_tree, value, row.key)?;
+                    }
+                }
+            }
+            if let Some(index_info) = self.indexes.get_mut(&index_name) {
+                index_info.root_page = new_root;
+            }
+            rebuilt += 1;
+        }
+
+        Ok(rebuilt)
     }
 
     /// Drop a table if it exists. Returns true if the table was removed.

--- a/src/storage/btree.rs
+++ b/src/storage/btree.rs
@@ -1,11 +1,12 @@
 use crate::storage::page::{
-    HEADER_SIZE, NODE_INTERNAL, NODE_LEAF, PAGE_SIZE, get_cell_count, get_next_leaf, get_node_type,
-    get_parent, set_cell_count, set_is_root, set_next_leaf, set_node_type, set_parent,
+    get_cell_count, get_next_leaf, get_node_type, get_parent, set_cell_count, set_is_root,
+    set_next_leaf, set_node_type, set_parent, HEADER_SIZE, NODE_INTERNAL, NODE_LEAF, PAGE_SIZE,
 };
 use crate::storage::pager::Pager;
-use crate::storage::row::{COMMITTED_BOOTSTRAP_TX, Row, RowData};
+use crate::storage::row::{Row, RowData, COMMITTED_BOOTSTRAP_TX};
+use crate::storage::vacuum::deleted_version_is_removable;
 use crate::transaction::{
-    Snapshot, TransactionId, TransactionStatus, TransactionTable, is_visible,
+    is_visible, Snapshot, TransactionId, TransactionStatus, TransactionTable,
 };
 use log::debug;
 use std::io;
@@ -354,6 +355,37 @@ impl<'a> BTree<'a> {
             page_num = next;
         }
         Ok(rows)
+    }
+
+    /// Physically remove deleted row versions that are older than every active
+    /// snapshot boundary. This is an explicit maintenance API; it is never
+    /// called automatically by DML paths.
+    pub fn vacuum_deleted_versions(
+        &mut self,
+        global_xmin: TransactionId,
+        tx_table: &TransactionTable,
+    ) -> io::Result<usize> {
+        let mut removed = 0;
+        let mut page_num = self.leftmost_leaf_page()?;
+        loop {
+            let rows = self.read_all_rows_from_leaf(page_num)?;
+            let before = rows.len();
+            let kept: Vec<Row> = rows
+                .into_iter()
+                .filter(|row| !deleted_version_is_removable(row.deleted_tx, global_xmin, tx_table))
+                .collect();
+            removed += before - kept.len();
+            if kept.len() != before {
+                self.write_all_rows_to_leaf(page_num, &kept)?;
+            }
+
+            let next = get_next_leaf(&self.pager.get_page(page_num)?.data);
+            if next == 0 {
+                break;
+            }
+            page_num = next;
+        }
+        Ok(removed)
     }
 
     fn insert_row_version_into_page(&mut self, page_num: u32, row: Row) -> io::Result<()> {
@@ -1171,11 +1203,9 @@ mod tests {
 
         btree.insert_version(row_with_tx(1, "after", 4)).unwrap();
 
-        assert!(
-            btree
-                .has_write_conflict(1, visible.created_tx, &snapshot)
-                .unwrap()
-        );
+        assert!(btree
+            .has_write_conflict(1, visible.created_tx, &snapshot)
+            .unwrap());
     }
 
     #[test]
@@ -1189,10 +1219,36 @@ mod tests {
 
         assert!(btree.mark_deleted_visible(1, &snapshot, 4).unwrap());
 
-        assert!(
-            btree
-                .has_write_conflict(1, visible.created_tx, &snapshot)
-                .unwrap()
-        );
+        assert!(btree
+            .has_write_conflict(1, visible.created_tx, &snapshot)
+            .unwrap());
+    }
+
+    #[test]
+    fn vacuum_prunes_only_committed_deletes_below_global_xmin() {
+        let file = NamedTempFile::new().unwrap();
+        let mut pager = Pager::new(file.path().to_str().unwrap()).unwrap();
+        let mut btree = BTree::new(&mut pager).unwrap();
+        let mut removable = row_with_tx(1, "old", 1);
+        removable.deleted_tx = Some(3);
+        let mut active_delete = row_with_tx(2, "active-delete", 1);
+        active_delete.deleted_tx = Some(4);
+        let mut protected = row_with_tx(3, "protected", 1);
+        protected.deleted_tx = Some(7);
+        btree.insert_version(removable).unwrap();
+        btree.insert_version(active_delete).unwrap();
+        btree.insert_version(protected).unwrap();
+
+        let tx_table = TransactionTable::from([
+            (3, TransactionStatus::Committed(1)),
+            (4, TransactionStatus::Active),
+            (7, TransactionStatus::Committed(2)),
+        ]);
+
+        assert_eq!(btree.vacuum_deleted_versions(6, &tx_table).unwrap(), 1);
+        let rows = btree.collect_all_rows().unwrap();
+        assert!(rows.iter().all(|row| row.key != 1));
+        assert!(rows.iter().any(|row| row.key == 2));
+        assert!(rows.iter().any(|row| row.key == 3));
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3,3 +3,4 @@ mod dirty_pages;
 pub mod page;
 pub mod pager;
 pub mod row;
+pub mod vacuum;

--- a/src/storage/vacuum.rs
+++ b/src/storage/vacuum.rs
@@ -1,0 +1,28 @@
+use crate::transaction::{TransactionId, TransactionStatus, TransactionTable};
+
+/// Summary of one explicit vacuum pass.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct VacuumReport {
+    /// Physical row versions removed from table B-Tree leaves.
+    pub versions_removed: usize,
+    /// Index B-Trees rebuilt to drop stale logical row-key candidates.
+    pub indexes_cleaned: usize,
+}
+
+/// Returns true when an MVCC row version whose `deleted_tx` is present can be
+/// physically removed without becoming visible to any active snapshot.
+pub fn deleted_version_is_removable(
+    deleted_tx: Option<TransactionId>,
+    global_xmin: TransactionId,
+    tx_table: &TransactionTable,
+) -> bool {
+    let Some(deleted_tx) = deleted_tx else {
+        return false;
+    };
+
+    deleted_tx < global_xmin
+        && matches!(
+            tx_table.get(&deleted_tx),
+            Some(TransactionStatus::Committed(_))
+        )
+}


### PR DESCRIPTION
### Motivation

- Provide an explicit internal maintenance API to physically prune obsolete MVCC row versions and remove stale index candidates left by UPDATE/DELETE. 
- Ensure physical pruning only removes versions that are safe for all active snapshots (i.e. committed and older than the global xmin). 

### Description

- Add `src/storage/vacuum.rs` with `VacuumReport` and the predicate `deleted_version_is_removable` that returns true only when `deleted_tx` is committed and below `global_xmin`.
- Export the vacuum module via `src/storage/mod.rs` and add `BTree::vacuum_deleted_versions` in `src/storage/btree.rs` to scan leaf pages and physically remove removable (deleted) versions.
- Add catalog-level helpers in `src/catalog/mod.rs`: `global_xmin()` computes the cutoff (oldest active tx or next tx id), `vacuum_table()` performs table vacuum and returns a `VacuumReport`, and `rebuild_indexes_for_table()` lazily rebuilds indexes when pruning occurred.
- Add a unit test `vacuum_prunes_only_committed_deletes_below_global_xmin` in the B-Tree tests covering committed, active, and protected delete cases.

### Testing

- Ran the full test suite with `cargo test`, which completed successfully (all tests passed).
- Ran the new focused test `cargo test storage::btree::tests::vacuum_prunes_only_committed_deletes_below_global_xmin`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50b60971288333a90f1b81d497deb7)