### PR TITLE
Make constraints MVCC-aware

### DIFF
--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -266,9 +266,142 @@ impl Catalog {
     pub fn commit_transaction(&mut self) -> io::Result<()> {
         let transaction_id = self.transaction_id();
         debug!("Transaction committed: {:?}", transaction_id);
+        if let Some(transaction_id) = transaction_id {
+            self.recheck_constraints_for_commit(transaction_id)
+                .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+        }
         self.pager.commit_transaction()?;
         if let Some(transaction_id) = transaction_id {
             self.finish_transaction_id(transaction_id);
+        }
+        Ok(())
+    }
+
+    fn recheck_constraints_for_commit(
+        &mut self,
+        transaction_id: TransactionId,
+    ) -> crate::error::DbResult<()> {
+        let snapshot =
+            Snapshot::new_for_transaction(transaction_id, TransactionId::MAX, Vec::new());
+        let tables = self.all_tables();
+
+        for table in &tables {
+            if let Some(pk_cols) = &table.primary_key {
+                let mut tree = BTree::open_root(&mut self.pager, table.root_page)?;
+                let rows = tree.scan_visible(&snapshot)?;
+                for (idx, row) in rows.iter().enumerate() {
+                    if row.created_tx != transaction_id {
+                        continue;
+                    }
+                    if rows.iter().skip(idx + 1).any(|other| {
+                        pk_cols.iter().all(|col| {
+                            table
+                                .columns
+                                .iter()
+                                .position(|(name, _)| name == col)
+                                .map(|pos| row.data.0[pos] == other.data.0[pos])
+                                .unwrap_or(false)
+                        })
+                    }) {
+                        return Err(crate::error::DbError::DuplicateKey(row.key));
+                    }
+                }
+            }
+
+            let mut tree = BTree::open_root(&mut self.pager, table.root_page)?;
+            let versions = tree.all_versions()?;
+            drop(tree);
+
+            for row in versions
+                .iter()
+                .filter(|row| row.created_tx == transaction_id && row.deleted_tx.is_none())
+            {
+                self.recheck_foreign_keys_for_row(table, &row.data, &snapshot)?;
+            }
+
+            for row in versions
+                .iter()
+                .filter(|row| row.deleted_tx == Some(transaction_id))
+            {
+                self.recheck_referential_delete_for_row(table, &row.data, &snapshot)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn recheck_foreign_keys_for_row(
+        &mut self,
+        table: &TableInfo,
+        row: &RowData,
+        snapshot: &Snapshot,
+    ) -> crate::error::DbResult<()> {
+        for fk in &table.fks {
+            if fk.columns.is_empty() || fk.parent_columns.is_empty() {
+                continue;
+            }
+            let child_idx = table
+                .columns
+                .iter()
+                .position(|(name, _)| name == &fk.columns[0])
+                .ok_or_else(|| crate::error::DbError::ColumnNotFound(fk.columns[0].clone()))?;
+            let ColumnValue::Integer(child_val) = row.0[child_idx] else {
+                return Err(crate::error::DbError::InvalidValue(
+                    "FK column must be INTEGER".into(),
+                ));
+            };
+            let parent = self.get_table(&fk.parent_table)?.clone();
+            let mut parent_tree = BTree::open_root(&mut self.pager, parent.root_page)?;
+            if parent_tree.find_visible(child_val, snapshot)?.is_none() {
+                return Err(crate::error::DbError::ForeignKeyViolation(format!(
+                    "{} {}",
+                    fk.parent_table, child_val
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn recheck_referential_delete_for_row(
+        &mut self,
+        table: &TableInfo,
+        row: &RowData,
+        snapshot: &Snapshot,
+    ) -> crate::error::DbResult<()> {
+        for child in self.all_tables() {
+            for fk in &child.fks {
+                if fk.parent_table != table.name
+                    || fk.columns.is_empty()
+                    || fk.parent_columns.is_empty()
+                {
+                    continue;
+                }
+                if fk.on_delete == Some(crate::sql::ast::Action::Cascade) {
+                    continue;
+                }
+                let parent_idx = table
+                    .columns
+                    .iter()
+                    .position(|(name, _)| name == &fk.parent_columns[0])
+                    .unwrap();
+                let ColumnValue::Integer(parent_val) = row.0[parent_idx] else {
+                    continue;
+                };
+                let child_idx = child
+                    .columns
+                    .iter()
+                    .position(|(name, _)| name == &fk.columns[0])
+                    .unwrap();
+                let mut child_tree = BTree::open_root(&mut self.pager, child.root_page)?;
+                for child_row in child_tree.scan_visible(snapshot)? {
+                    if child_row.data.0[child_idx] == ColumnValue::Integer(parent_val) {
+                        return Err(crate::error::DbError::ForeignKeyViolation(format!(
+                            "Cannot delete {}: referenced by {}.{}",
+                            table.name, child.name, fk.columns[0]
+                        )));
+                    }
+                }
+            }
         }
         Ok(())
     }

--- a/src/constraints/default.rs
+++ b/src/constraints/default.rs
@@ -1,7 +1,7 @@
-use crate::sql::ast::Expr;
-use crate::storage::row::ColumnValue;
-use crate::sql::functions::FunctionEvaluator;
 use crate::error::{DbError, DbResult};
+use crate::sql::ast::Expr;
+use crate::sql::functions::FunctionEvaluator;
+use crate::storage::row::ColumnValue;
 
 pub struct DefaultConstraint;
 
@@ -22,17 +22,26 @@ impl DefaultConstraint {
                     Err(_) => Err(DbError::InvalidValue("function error".into())),
                 }
             }
-            _ => Err(DbError::InvalidValue("unsupported default expression".into())),
+            _ => Err(DbError::InvalidValue(
+                "unsupported default expression".into(),
+            )),
         }
     }
 }
 
+use super::Constraint;
 use crate::catalog::{Catalog, TableInfo};
 use crate::storage::row::RowData;
-use super::Constraint;
+use crate::transaction::Snapshot;
 
 impl Constraint for DefaultConstraint {
-    fn validate_insert(&self, _catalog: &mut Catalog, _table: &TableInfo, _row: &mut RowData) -> DbResult<()> {
+    fn validate_insert(
+        &self,
+        _catalog: &mut Catalog,
+        _table: &TableInfo,
+        _row: &mut RowData,
+        _snapshot: &Snapshot,
+    ) -> DbResult<()> {
         Ok(())
     }
 }

--- a/src/constraints/foreign_key.rs
+++ b/src/constraints/foreign_key.rs
@@ -4,6 +4,7 @@ use crate::error::{DbError, DbResult};
 use crate::sql::ast::ForeignKey;
 use crate::storage::btree::BTree;
 use crate::storage::row::{ColumnValue, RowData};
+use crate::transaction::Snapshot;
 
 pub struct ForeignKeyConstraint<'a> {
     pub fks: &'a [ForeignKey],
@@ -15,6 +16,7 @@ impl<'a> Constraint for ForeignKeyConstraint<'a> {
         catalog: &mut Catalog,
         table: &TableInfo,
         row: &mut RowData,
+        snapshot: &Snapshot,
     ) -> DbResult<()> {
         for fk in self.fks {
             if fk.columns.is_empty() || fk.parent_columns.is_empty() {
@@ -30,11 +32,8 @@ impl<'a> Constraint for ForeignKeyConstraint<'a> {
                 _ => return Err(DbError::InvalidValue("FK column must be INTEGER".into())),
             };
             let parent_root = catalog.get_table(&fk.parent_table)?.root_page;
-            let snapshot = catalog
-                .current_snapshot()
-                .unwrap_or_else(|| crate::transaction::Snapshot::new(u64::MAX, Vec::new()));
             let mut parent_btree = BTree::open_root(&mut catalog.pager, parent_root)?;
-            if parent_btree.find_visible(child_val, &snapshot)?.is_none() {
+            if parent_btree.find_visible(child_val, snapshot)?.is_none() {
                 return Err(DbError::ForeignKeyViolation(format!(
                     "{} {}",
                     fk.parent_table, child_val
@@ -49,6 +48,7 @@ impl<'a> Constraint for ForeignKeyConstraint<'a> {
         catalog: &mut Catalog,
         table: &TableInfo,
         row: &RowData,
+        snapshot: &Snapshot,
     ) -> DbResult<()> {
         let columns = &table.columns;
         let child_tables: Vec<_> = catalog.all_tables();
@@ -70,11 +70,8 @@ impl<'a> Constraint for ForeignKeyConstraint<'a> {
                         .unwrap();
                     let mut matches: Vec<(i32, RowData)> = Vec::new();
                     {
-                        let snapshot = catalog.current_snapshot().unwrap_or_else(|| {
-                            crate::transaction::Snapshot::new(u64::MAX, Vec::new())
-                        });
                         let mut scan_tree = BTree::open_root(&mut catalog.pager, child.root_page)?;
-                        for crow in scan_tree.scan_visible(&snapshot)? {
+                        for crow in scan_tree.scan_visible(snapshot)? {
                             if let ColumnValue::Integer(v) = crow.data.0[child_idx] {
                                 if v == parent_val {
                                     matches.push((crow.key, crow.data.clone()));
@@ -84,16 +81,13 @@ impl<'a> Constraint for ForeignKeyConstraint<'a> {
                     }
                     if !matches.is_empty() {
                         if fk.on_delete == Some(crate::sql::ast::Action::Cascade) {
-                            let snapshot = catalog.current_snapshot().unwrap_or_else(|| {
-                                crate::transaction::Snapshot::new(u64::MAX, Vec::new())
-                            });
                             let tx_id = snapshot
                                 .current_tx_id
                                 .unwrap_or(crate::storage::row::COMMITTED_BOOTSTRAP_TX);
                             let mut del_tree =
                                 BTree::open_root(&mut catalog.pager, child.root_page)?;
                             for (k, _) in &matches {
-                                del_tree.mark_deleted_visible(*k, &snapshot, tx_id)?;
+                                del_tree.mark_deleted_visible(*k, snapshot, tx_id)?;
                             }
                             let new_root_c = del_tree.root_page();
                             drop(del_tree);

--- a/src/constraints/mod.rs
+++ b/src/constraints/mod.rs
@@ -1,15 +1,28 @@
-pub mod not_null;
 pub mod default;
 pub mod foreign_key;
+pub mod not_null;
 pub mod primary_key;
 
 use crate::catalog::{Catalog, TableInfo};
-use crate::storage::row::RowData;
 use crate::error::DbResult;
+use crate::storage::row::RowData;
+use crate::transaction::Snapshot;
 
 pub trait Constraint {
-    fn validate_insert(&self, catalog: &mut Catalog, table: &TableInfo, row: &mut RowData) -> DbResult<()>;
-    fn validate_delete(&self, _catalog: &mut Catalog, _table: &TableInfo, _row: &RowData) -> DbResult<()> {
+    fn validate_insert(
+        &self,
+        catalog: &mut Catalog,
+        table: &TableInfo,
+        row: &mut RowData,
+        snapshot: &Snapshot,
+    ) -> DbResult<()>;
+    fn validate_delete(
+        &self,
+        _catalog: &mut Catalog,
+        _table: &TableInfo,
+        _row: &RowData,
+        _snapshot: &Snapshot,
+    ) -> DbResult<()> {
         Ok(())
     }
 }

--- a/src/constraints/not_null.rs
+++ b/src/constraints/not_null.rs
@@ -1,14 +1,26 @@
-use crate::catalog::TableInfo;
-use crate::storage::row::{RowData, ColumnValue};
-use crate::catalog::Catalog;
-use crate::error::{DbError, DbResult};
 use super::Constraint;
+use crate::catalog::Catalog;
+use crate::catalog::TableInfo;
+use crate::error::{DbError, DbResult};
+use crate::storage::row::{ColumnValue, RowData};
+use crate::transaction::Snapshot;
 
 pub struct NotNullConstraint;
 
 impl Constraint for NotNullConstraint {
-    fn validate_insert(&self, _catalog: &mut Catalog, table: &TableInfo, row: &mut RowData) -> DbResult<()> {
-        for ((val, nn), (name, _)) in row.0.iter().zip(table.not_null.iter()).zip(table.columns.iter()) {
+    fn validate_insert(
+        &self,
+        _catalog: &mut Catalog,
+        table: &TableInfo,
+        row: &mut RowData,
+        _snapshot: &Snapshot,
+    ) -> DbResult<()> {
+        for ((val, nn), (name, _)) in row
+            .0
+            .iter()
+            .zip(table.not_null.iter())
+            .zip(table.columns.iter())
+        {
             if *nn && matches!(val, ColumnValue::Null) {
                 return Err(DbError::NullViolation(name.clone()));
             }

--- a/src/constraints/primary_key.rs
+++ b/src/constraints/primary_key.rs
@@ -3,6 +3,7 @@ use crate::catalog::{Catalog, TableInfo};
 use crate::error::{DbError, DbResult};
 use crate::storage::btree::BTree;
 use crate::storage::row::{ColumnValue, RowData};
+use crate::transaction::Snapshot;
 
 pub struct PrimaryKeyConstraint<'a> {
     pub columns: &'a [String],
@@ -14,6 +15,7 @@ impl<'a> Constraint for PrimaryKeyConstraint<'a> {
         catalog: &mut Catalog,
         table: &TableInfo,
         row: &mut RowData,
+        snapshot: &Snapshot,
     ) -> DbResult<()> {
         // ensure not null
         for col in self.columns {
@@ -24,11 +26,8 @@ impl<'a> Constraint for PrimaryKeyConstraint<'a> {
             }
         }
         // check uniqueness
-        let snapshot = catalog
-            .current_snapshot()
-            .unwrap_or_else(|| crate::transaction::Snapshot::new(u64::MAX, Vec::new()));
         let mut btree = BTree::open_root(&mut catalog.pager, table.root_page)?;
-        for existing in btree.scan_visible(&snapshot)? {
+        for existing in btree.scan_visible(snapshot)? {
             let mut equal = true;
             for col in self.columns {
                 if let Some(idx) = table.columns.iter().position(|(c, _)| c == col) {

--- a/src/execution/runtime.rs
+++ b/src/execution/runtime.rs
@@ -111,7 +111,7 @@ pub fn execute_delete(
                 fks: &table_info.fks,
             };
             for row in &rows_to_delete {
-                fk_cons.validate_delete(catalog, &table_info, &row.data)?;
+                fk_cons.validate_delete(catalog, &table_info, &row.data, &dml_snapshot(catalog))?;
             }
 
             let count = rows_to_delete.len();
@@ -298,12 +298,22 @@ pub fn execute_update(
 
             for op in &mut ops {
                 let nn = NotNullConstraint;
-                nn.validate_insert(catalog, &table_info, &mut op.new_data)?;
+                nn.validate_insert(
+                    catalog,
+                    &table_info,
+                    &mut op.new_data,
+                    &dml_snapshot(catalog),
+                )?;
 
                 let fk_cons = ForeignKeyConstraint {
                     fks: &table_info.fks,
                 };
-                fk_cons.validate_insert(catalog, &table_info, &mut op.new_data)?;
+                fk_cons.validate_insert(
+                    catalog,
+                    &table_info,
+                    &mut op.new_data,
+                    &dml_snapshot(catalog),
+                )?;
             }
 
             if let Some(ref pk_cols) = table_info.primary_key {
@@ -518,13 +528,18 @@ pub fn execute_insert(
                 build_row_data(&vals, &columns_meta).map_err(|e| DbError::InvalidValue(e))?;
 
             let nn = NotNullConstraint;
-            nn.validate_insert(catalog, &table_info, &mut row_data)?;
+            nn.validate_insert(catalog, &table_info, &mut row_data, &dml_snapshot(catalog))?;
 
             let fk_cons = ForeignKeyConstraint { fks: &fks };
-            fk_cons.validate_insert(catalog, &table_info, &mut row_data)?;
+            fk_cons.validate_insert(catalog, &table_info, &mut row_data, &dml_snapshot(catalog))?;
             if let Some(ref pk_cols) = table_info.primary_key {
                 let pk_cons = PrimaryKeyConstraint { columns: pk_cols };
-                pk_cons.validate_insert(catalog, &table_info, &mut row_data)?;
+                pk_cons.validate_insert(
+                    catalog,
+                    &table_info,
+                    &mut row_data,
+                    &dml_snapshot(catalog),
+                )?;
             }
             let key = match row_data.0.get(0) {
                 Some(ColumnValue::Integer(i)) => *i,

--- a/src/storage/btree.rs
+++ b/src/storage/btree.rs
@@ -1,12 +1,12 @@
 use crate::storage::page::{
-    get_cell_count, get_next_leaf, get_node_type, get_parent, set_cell_count, set_is_root,
-    set_next_leaf, set_node_type, set_parent, HEADER_SIZE, NODE_INTERNAL, NODE_LEAF, PAGE_SIZE,
+    HEADER_SIZE, NODE_INTERNAL, NODE_LEAF, PAGE_SIZE, get_cell_count, get_next_leaf, get_node_type,
+    get_parent, set_cell_count, set_is_root, set_next_leaf, set_node_type, set_parent,
 };
 use crate::storage::pager::Pager;
-use crate::storage::row::{Row, RowData, COMMITTED_BOOTSTRAP_TX};
+use crate::storage::row::{COMMITTED_BOOTSTRAP_TX, Row, RowData};
 use crate::storage::vacuum::deleted_version_is_removable;
 use crate::transaction::{
-    is_visible, Snapshot, TransactionId, TransactionStatus, TransactionTable,
+    Snapshot, TransactionId, TransactionStatus, TransactionTable, is_visible,
 };
 use log::debug;
 use std::io;
@@ -355,6 +355,13 @@ impl<'a> BTree<'a> {
             page_num = next;
         }
         Ok(rows)
+    }
+
+    /// Return every physical row version, including versions that have been
+    /// logically deleted. Commit-time constraint rechecks use this to validate
+    /// rows written or deleted by the committing transaction.
+    pub fn all_versions(&mut self) -> io::Result<Vec<Row>> {
+        self.collect_all_rows()
     }
 
     /// Physically remove deleted row versions that are older than every active
@@ -1203,9 +1210,11 @@ mod tests {
 
         btree.insert_version(row_with_tx(1, "after", 4)).unwrap();
 
-        assert!(btree
-            .has_write_conflict(1, visible.created_tx, &snapshot)
-            .unwrap());
+        assert!(
+            btree
+                .has_write_conflict(1, visible.created_tx, &snapshot)
+                .unwrap()
+        );
     }
 
     #[test]
@@ -1219,9 +1228,11 @@ mod tests {
 
         assert!(btree.mark_deleted_visible(1, &snapshot, 4).unwrap());
 
-        assert!(btree
-            .has_write_conflict(1, visible.created_tx, &snapshot)
-            .unwrap());
+        assert!(
+            btree
+                .has_write_conflict(1, visible.created_tx, &snapshot)
+                .unwrap()
+        );
     }
 
     #[test]

--- a/tests/constraints_module.rs
+++ b/tests/constraints_module.rs
@@ -1,8 +1,12 @@
-use aerodb::constraints::{Constraint, not_null::NotNullConstraint, default::DefaultConstraint, foreign_key::ForeignKeyConstraint};
-use aerodb::storage::row::{RowData, ColumnValue, ColumnType};
 use aerodb::catalog::{Catalog, TableInfo};
+use aerodb::constraints::{
+    Constraint, default::DefaultConstraint, foreign_key::ForeignKeyConstraint,
+    not_null::NotNullConstraint,
+};
 use aerodb::sql::ast::ForeignKey;
 use aerodb::storage::pager::Pager;
+use aerodb::storage::row::{ColumnType, ColumnValue, RowData};
+use aerodb::transaction::Snapshot;
 use std::fs;
 
 fn setup_catalog(filename: &str) -> Catalog {
@@ -26,7 +30,12 @@ fn not_null_constraint_fails_on_null() {
     let mut row = RowData(vec![ColumnValue::Null]);
     let mut catalog = setup_catalog("nn_fail.db");
     let constraint = NotNullConstraint;
-    let res = constraint.validate_insert(&mut catalog, &table, &mut row);
+    let res = constraint.validate_insert(
+        &mut catalog,
+        &table,
+        &mut row,
+        &Snapshot::new(u64::MAX, Vec::new()),
+    );
     assert!(res.is_err());
 }
 
@@ -67,7 +76,13 @@ fn foreign_key_constraint_detects_missing_parent() {
         not_null: vec![false],
         default_values: vec![None],
         auto_increment: vec![false],
-        fks: vec![ForeignKey { columns: vec!["pid".into()], parent_table: "p".into(), parent_columns: vec!["id".into()], on_delete: None, on_update: None }],
+        fks: vec![ForeignKey {
+            columns: vec!["pid".into()],
+            parent_table: "p".into(),
+            parent_columns: vec!["id".into()],
+            on_delete: None,
+            on_update: None,
+        }],
         primary_key: None,
     };
     catalog
@@ -80,6 +95,11 @@ fn foreign_key_constraint_detects_missing_parent() {
         .unwrap();
     let mut row = RowData(vec![ColumnValue::Integer(1)]);
     let constraint = ForeignKeyConstraint { fks: &child.fks };
-    let res = constraint.validate_insert(&mut catalog, &child, &mut row);
+    let res = constraint.validate_insert(
+        &mut catalog,
+        &child,
+        &mut row,
+        &Snapshot::new(u64::MAX, Vec::new()),
+    );
     assert!(res.is_err());
 }


### PR DESCRIPTION
### Motivation

- Ensure constraint checks observe MVCC visibility so DML behaves correctly under concurrent transactions by evaluating constraints against the caller’s snapshot and rechecking at commit time to detect conflicts.

### Description

- Thread `Snapshot` through the `Constraint` trait and update constraint implementations so `validate_insert`/`validate_delete` accept a `&Snapshot` and evaluate visibility-aware lookups.
- Use `BTree::scan_visible(snapshot)` for primary-key uniqueness checks and `BTree::find_visible(..., snapshot)` / `scan_visible(snapshot)` for foreign-key parent lookups and child referential checks.
- Add commit-time rechecks in `Catalog::commit_transaction` (`recheck_constraints_for_commit`) to detect transaction-level conflicts by inspecting versions written/deleted by the committing transaction via a new `BTree::all_versions()` API and returning appropriate constraint errors (`DuplicateKey` / `ForeignKeyViolation`).
- Update runtime DML call sites to pass the current DML snapshot (`dml_snapshot(catalog)`) into constraint validators and adjust tests to the new signatures.

### Testing

- Ran the full test suite with `cargo test`, which completed successfully (all unit and integration tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50b8e6f9d883339f7edd272514cc71)